### PR TITLE
Fix join crash

### DIFF
--- a/MoreCompany/HudPatches.cs
+++ b/MoreCompany/HudPatches.cs
@@ -159,7 +159,7 @@ namespace MoreCompany
 			{
 				GameObject.Destroy(gameObject);
 			}
-			if (!StartOfRound.Instance)
+			if (!StartOfRound.Instance || !StartOfRound.Instance.localPlayerController)
 			{
 				return;
 			}


### PR DESCRIPTION
There was a bug where for some reason `StartOfRound.Instance.localPlayerController` wouldn't be set by the time it was used when a player joins. I simply added a check to not let it reach that point.