### PR TITLE
Fixed Chat Message Out Of Bounds Exception

### DIFF
--- a/MoreCompany/ChatPatches.cs
+++ b/MoreCompany/ChatPatches.cs
@@ -108,6 +108,7 @@ namespace MoreCompany
                 {
                     chatMessage = ServerReceiveMessagePatch.previousDataMessage;
                     HandleDataMessage(ref chatMessage);
+                    return false;
                 }
                 else if (chatMessage.StartsWith("[morecompanycosmetics]"))
                 {
@@ -120,6 +121,7 @@ namespace MoreCompany
                 if (chatMessage.StartsWith("[morecompanycosmetics]"))
                 {
                     HandleDataMessage(ref chatMessage);
+                    return false;
                 }
             }
 


### PR DESCRIPTION
- Fixed an error when syncing cosmetics using chat due to the player id being out of bounds.