### PR TITLE
Improved EnablePlayerObjectsBasedOnConnected

### DIFF
--- a/MoreCompany/HudPatches.cs
+++ b/MoreCompany/HudPatches.cs
@@ -123,7 +123,6 @@ namespace MoreCompany
         private static bool Prefix(QuickMenuManager __instance, ulong steamId, string playerName, int playerObjectId)
         {
             QuickmenuVisualInjectPatch.PopulateQuickMenu(__instance);
-            MainClass.EnablePlayerObjectsBasedOnConnected();
             return false;
         }
     }


### PR DESCRIPTION
- Made all player controllers disabled by default then only enable/disable the relevant one when a player connects/disconnects.

The reason for this change is to fix a race condition that can occur when two players join at the same time which can result in them getting stuck in the wall due to their player controller being disabled. Was discovered by someone in the LC modding discord server.