### PR TITLE
Fixed the EnablePlayerObjectsBasedOnConnected PR

### DIFF
--- a/MoreCompany/ChatPatches.cs
+++ b/MoreCompany/ChatPatches.cs
@@ -94,7 +94,7 @@ namespace MoreCompany
     {
         public static bool ignoreSample = false;
         
-        public static bool Prefix(ref HUDManager __instance, string chatMessage, int playerId)
+        public static bool Prefix(HUDManager __instance, string chatMessage, int playerId)
         {
             NetworkManager networkManager = __instance.NetworkManager;
             if (networkManager == null || !networkManager.IsListening)
@@ -107,6 +107,7 @@ namespace MoreCompany
                 if (chatMessage.StartsWith("[replacewithdata]"))
                 {
                     HandleDataMessage(ServerReceiveMessagePatch.previousDataMessage);
+                    return false;
                 }
                 else if (chatMessage.StartsWith("[morecompanycosmetics]"))
                 {
@@ -119,6 +120,7 @@ namespace MoreCompany
                 if (chatMessage.StartsWith("[morecompanycosmetics]"))
                 {
                     HandleDataMessage(chatMessage);
+                    return false;
                 }
             }
 

--- a/MoreCompany/MainClass.cs
+++ b/MoreCompany/MainClass.cs
@@ -255,7 +255,6 @@ namespace MoreCompany
             foreach (PlayerControllerB newPlayerScript in StartOfRound.Instance.allPlayerScripts) // Fix for billboards showing as Player # with no number in LAN (base game issue)
             {
                 newPlayerScript.usernameBillboardText.text = newPlayerScript.playerUsername;
-                newPlayerScript.gameObject.SetActive(false);
             }
         }
     }
@@ -491,16 +490,6 @@ namespace MoreCompany
     [HarmonyPatch]
     public static class TogglePlayerObjectsPatch
     {
-        [HarmonyPatch(typeof(StartOfRound), "Update")]
-        [HarmonyPrefix]
-        private static void SORUpdate(StartOfRound __instance, bool ___hasHostSpawned)
-        {
-            if (GameNetworkManager.Instance != null && __instance.IsServer && !___hasHostSpawned)
-            {
-                __instance.allPlayerObjects[0].gameObject.SetActive(true);
-            }
-        }
-
         [HarmonyPatch(typeof(PlayerControllerB), "ConnectClientToPlayerObject")]
         [HarmonyPrefix]
         private static void ConnectClientToPlayerObject()
@@ -511,6 +500,10 @@ namespace MoreCompany
                 if (flag)
                 {
                     playerControllerB.gameObject.SetActive(true);
+                }
+                else
+                {
+                    playerControllerB.gameObject.SetActive(false);
                 }
             }
         }


### PR DESCRIPTION
- Re-added the two `return false` to the chat code since apparently reverting to the original code from the latest 1.7 version still somehow has the chat rpc error.
- Fixed the EnablePlayerObjectsBasedOnConnected PR not working due to the player objects being disabled too early.