### PR TITLE
Cosmetic Config Options

### DIFF
--- a/MoreCompany/ChatPatches.cs
+++ b/MoreCompany/ChatPatches.cs
@@ -95,24 +95,21 @@ namespace MoreCompany
 
         [HarmonyPatch(typeof(HUDManager), "AddTextMessageClientRpc")]
         [HarmonyPrefix]
-        public static bool AddTextMessageClientRpc_Prefix(HUDManager __instance, string chatMessage)
+        public static void AddTextMessageClientRpc_Prefix(HUDManager __instance, string chatMessage)
         {
             if (chatMessage.StartsWith("[morecompanycosmetics]"))
             {
                 NetworkManager networkManager = __instance.NetworkManager;
                 if (networkManager == null || !networkManager.IsListening)
                 {
-                    return false;
+                    return;
                 }
 
                 if ((__RpcExecStage)__rpc_exec_stage.GetValue(__instance) == __RpcExecStage.Client && (networkManager.IsClient || networkManager.IsHost))
                 {
                     HandleDataMessage(chatMessage);
-                    return false;
                 }
             }
-
-            return true;
         }
 
         internal static void HandleDataMessage(string chatMessage)

--- a/MoreCompany/ChatPatches.cs
+++ b/MoreCompany/ChatPatches.cs
@@ -163,7 +163,7 @@ namespace MoreCompany
                 }
                 cosmeticsToApply.Add(cosmeticId);
 
-                if (MainClass.showCosmetics)
+                if (MainClass.showCosmetics.Value)
                 {
                     cosmeticApplication.ApplyCosmetic(cosmeticId, true);
                 }

--- a/MoreCompany/ChatPatches.cs
+++ b/MoreCompany/ChatPatches.cs
@@ -124,8 +124,6 @@ namespace MoreCompany
 
             if (targetId != -1 && targetId != StartOfRound.Instance.thisClientPlayerId) { return; }
 
-            MainClass.StaticLogger.LogWarning($"[TEST] HandleDataMessage ({senderId} > {targetId}): {string.Join(';', splitMessage)}");
-
             CosmeticApplication cosmeticApplication = StartOfRound.Instance.allPlayerScripts[senderId].transform.Find("ScavengerModel")
                 .Find("metarig").gameObject.GetComponent<CosmeticApplication>();
 

--- a/MoreCompany/ChatPatches.cs
+++ b/MoreCompany/ChatPatches.cs
@@ -54,7 +54,6 @@ namespace MoreCompany
             {
                 if (!MainClass.cosmeticsSyncHost.Value)
                 {
-                    MainClass.StaticLogger.LogWarning("[TEST] Prevented Sync: " + chatMessage);
                     return false;
                 }
                 previousDataMessage = chatMessage;

--- a/MoreCompany/ChatPatches.cs
+++ b/MoreCompany/ChatPatches.cs
@@ -142,10 +142,15 @@ namespace MoreCompany
             {
                 cosmeticsToApply.Add(cosmeticId);
 
-                if (MainClass.cosmeticsSyncOther.Value && senderId != StartOfRound.Instance.thisClientPlayerId)
+                if (MainClass.cosmeticsSyncOther.Value)
                 {
                     cosmeticApplication.ApplyCosmetic(cosmeticId, true);
                 }
+            }
+
+            if (senderId == StartOfRound.Instance.thisClientPlayerId)
+            {
+                cosmeticApplication.ClearCosmetics();
             }
 
             foreach (var cosmeticSpawned in cosmeticApplication.spawnedCosmetics)

--- a/MoreCompany/ChatPatches.cs
+++ b/MoreCompany/ChatPatches.cs
@@ -75,7 +75,10 @@ namespace MoreCompany
                 built += ";" + __instance.playerClientId;
                 foreach (var cosmetic in CosmeticRegistry.locallySelectedCosmetics)
                 {
-                    built += ";" + cosmetic;
+                    if (CosmeticRegistry.cosmeticInstances.ContainsKey(cosmetic))
+                    {
+                        built += ";" + cosmetic;
+                    }
                 }
                 HUDManager.Instance.AddTextToChatOnServer(built);
             }

--- a/MoreCompany/Cosmetics/CosmeticRegistry.cs
+++ b/MoreCompany/Cosmetics/CosmeticRegistry.cs
@@ -56,7 +56,7 @@ namespace MoreCompany.Cosmetics
 
         public static void UpdateVisibilityCheckbox(GameObject enableCosmeticsButton, GameObject disableCosmeticsButton)
         {
-            if (MainClass.showCosmetics.Value)
+            if (MainClass.cosmeticsSyncOther.Value)
             {
                 enableCosmeticsButton.SetActive(false);
                 disableCosmeticsButton.SetActive(true);
@@ -82,31 +82,13 @@ namespace MoreCompany.Cosmetics
             GameObject disableCosmeticsButton = cosmeticGUI.transform.Find("Canvas").Find("GlobalScale").Find("CosmeticsScreen").Find("DisableButton").gameObject;
             enableCosmeticsButton.GetComponent<Button>().onClick.AddListener(() =>
             {
-                if (!MainClass.showCosmeticsForced.Value)
-                {
-                    MainClass.showCosmetics.Value = true;
-                    MainClass.StaticConfig.Save();
-                }
-                else
-                {
-                    UpdateVisibilityCheckbox(enableCosmeticsButton, disableCosmeticsButton);
-                    GameObject.Find("CosmeticsScreen/ExitButton").GetComponent<Button>().onClick.Invoke();
-                    Object.FindObjectOfType<MenuManager>().DisplayMenuNotification("This button is disabled in the MoreCompany config!", "[ Back ]");
-                }
+                MainClass.cosmeticsSyncOther.Value = true;
+                MainClass.StaticConfig.Save();
             });
             disableCosmeticsButton.GetComponent<Button>().onClick.AddListener(() =>
             {
-                if (!MainClass.showCosmeticsForced.Value)
-                {
-                    MainClass.showCosmetics.Value = false;
-                    MainClass.StaticConfig.Save();
-                }
-                else
-                {
-                    UpdateVisibilityCheckbox(enableCosmeticsButton, disableCosmeticsButton);
-                    GameObject.Find("CosmeticsScreen/ExitButton").GetComponent<Button>().onClick.Invoke();
-                    Object.FindObjectOfType<MenuManager>().DisplayMenuNotification("This button is disabled in the MoreCompany config!", "[ Back ]");
-                }
+                MainClass.cosmeticsSyncOther.Value = false;
+                MainClass.StaticConfig.Save();
             });
 
             UpdateVisibilityCheckbox(enableCosmeticsButton, disableCosmeticsButton);

--- a/MoreCompany/Cosmetics/CosmeticRegistry.cs
+++ b/MoreCompany/Cosmetics/CosmeticRegistry.cs
@@ -54,6 +54,20 @@ namespace MoreCompany.Cosmetics
             }
         }
 
+        public static void UpdateVisibilityCheckbox(GameObject enableCosmeticsButton, GameObject disableCosmeticsButton)
+        {
+            if (MainClass.showCosmetics.Value)
+            {
+                enableCosmeticsButton.SetActive(false);
+                disableCosmeticsButton.SetActive(true);
+            }
+            else
+            {
+                enableCosmeticsButton.SetActive(true);
+                disableCosmeticsButton.SetActive(false);
+            }
+        }
+
         public static void SpawnCosmeticGUI()
         {
             cosmeticGUI = GameObject.Instantiate(MainClass.cosmeticGUIInstance);
@@ -65,30 +79,38 @@ namespace MoreCompany.Cosmetics
             cosmeticApplication = displayGuy.AddComponent<CosmeticApplication>();
             
             GameObject enableCosmeticsButton = cosmeticGUI.transform.Find("Canvas").Find("GlobalScale").Find("CosmeticsScreen").Find("EnableButton").gameObject;
+            GameObject disableCosmeticsButton = cosmeticGUI.transform.Find("Canvas").Find("GlobalScale").Find("CosmeticsScreen").Find("DisableButton").gameObject;
             enableCosmeticsButton.GetComponent<Button>().onClick.AddListener(() =>
             {
-                MainClass.showCosmetics = true;
-                MainClass.SaveSettingsToFile();
+                if (!MainClass.showCosmeticsForced.Value)
+                {
+                    MainClass.showCosmetics.Value = true;
+                    MainClass.StaticConfig.Save();
+                }
+                else
+                {
+                    UpdateVisibilityCheckbox(enableCosmeticsButton, disableCosmeticsButton);
+                    GameObject.Find("CosmeticsScreen/ExitButton").GetComponent<Button>().onClick.Invoke();
+                    Object.FindObjectOfType<MenuManager>().DisplayMenuNotification("This button is disabled in the MoreCompany config!", "[ Back ]");
+                }
             });
-            
-            GameObject disableCosmeticsButton = cosmeticGUI.transform.Find("Canvas").Find("GlobalScale").Find("CosmeticsScreen").Find("DisableButton").gameObject;
             disableCosmeticsButton.GetComponent<Button>().onClick.AddListener(() =>
             {
-                MainClass.showCosmetics = false;
-                MainClass.SaveSettingsToFile();
+                if (!MainClass.showCosmeticsForced.Value)
+                {
+                    MainClass.showCosmetics.Value = false;
+                    MainClass.StaticConfig.Save();
+                }
+                else
+                {
+                    UpdateVisibilityCheckbox(enableCosmeticsButton, disableCosmeticsButton);
+                    GameObject.Find("CosmeticsScreen/ExitButton").GetComponent<Button>().onClick.Invoke();
+                    Object.FindObjectOfType<MenuManager>().DisplayMenuNotification("This button is disabled in the MoreCompany config!", "[ Back ]");
+                }
             });
-            
-            if (MainClass.showCosmetics)
-            {
-                enableCosmeticsButton.SetActive(false);
-                disableCosmeticsButton.SetActive(true);
-            }
-            else
-            {
-                enableCosmeticsButton.SetActive(true);
-                disableCosmeticsButton.SetActive(false);
-            }
-            
+
+            UpdateVisibilityCheckbox(enableCosmeticsButton, disableCosmeticsButton);
+
             PopulateCosmetics();
             UpdateCosmeticsOnDisplayGuy(false);
         }

--- a/MoreCompany/EnemyAIPatches.cs
+++ b/MoreCompany/EnemyAIPatches.cs
@@ -175,24 +175,21 @@ namespace MoreCompany
         public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {
             var newInstructions = new List<CodeInstruction>();
-            bool alreadyReplaced = false;
+            int alreadyReplaced = 0;
             foreach (var instruction in instructions)
             {
-                if (!alreadyReplaced)
+                if (instruction.ToString() == "ldc.i4.4 NULL")
                 {
-                    if (instruction.ToString() == "ldc.i4.4 NULL")
-                    {
-                        CodeInstruction codeInstruction = new CodeInstruction(OpCodes.Ldsfld, AccessTools.Field(typeof(MainClass), "newPlayerCount"));
-                        newInstructions.Add(codeInstruction);
-                        alreadyReplaced = true;
-                        continue;
-                    }
+                    alreadyReplaced++;
+                    CodeInstruction codeInstruction = new CodeInstruction(OpCodes.Ldsfld, AccessTools.Field(typeof(MainClass), "newPlayerCount"));
+                    newInstructions.Add(codeInstruction);
+                    continue;
                 }
 
                 newInstructions.Add(instruction);
             }
 
-            if (!alreadyReplaced) MainClass.StaticLogger.LogWarning("DressGirlHauntPatch failed to replace newPlayerCount");
+            if (alreadyReplaced != 3) MainClass.StaticLogger.LogWarning($"DressGirlHauntPatch failed to replace newPlayerCount: {alreadyReplaced}/3");
 
             return newInstructions.AsEnumerable();
         }

--- a/MoreCompany/EnemyAIPatches.cs
+++ b/MoreCompany/EnemyAIPatches.cs
@@ -71,6 +71,8 @@ namespace MoreCompany
                 newInstructions.Add(instruction);
             }
 
+            if (!alreadyReplaced) MainClass.StaticLogger.LogWarning("SpringManAIUpdatePatch failed to replace newPlayerCount");
+
             return newInstructions.AsEnumerable();
         }
     }
@@ -103,6 +105,8 @@ namespace MoreCompany
 				newInstructions.Add(instruction);
             }
 
+            if (!alreadyReplaced) MainClass.StaticLogger.LogWarning("SpringManAIIntervalPatch failed to replace newPlayerCount");
+
             return newInstructions.AsEnumerable();
         }
 	}
@@ -129,6 +133,8 @@ namespace MoreCompany
 
                 newInstructions.Add(instruction);
             }
+
+            if (!alreadyReplaced) MainClass.StaticLogger.LogWarning("GetClosestPlayerPatch failed to replace newPlayerCount");
 
             return newInstructions.AsEnumerable();
         }
@@ -157,6 +163,8 @@ namespace MoreCompany
 				newInstructions.Add(instruction);
             }
 
+            if (!alreadyReplaced) MainClass.StaticLogger.LogWarning("GetAllPlayersInLineOfSightPatch failed to replace newPlayerCount");
+
             return newInstructions.AsEnumerable();
         }
     }
@@ -167,17 +175,24 @@ namespace MoreCompany
         public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {
             var newInstructions = new List<CodeInstruction>();
+            bool alreadyReplaced = false;
             foreach (var instruction in instructions)
             {
-                if (instruction.ToString() == "ldc.i4.4 NULL")
+                if (!alreadyReplaced)
                 {
-                    CodeInstruction codeInstruction = new CodeInstruction(OpCodes.Ldsfld, AccessTools.Field(typeof(MainClass), "newPlayerCount"));
-                    newInstructions.Add(codeInstruction);
-                    continue;
+                    if (instruction.ToString() == "ldc.i4.4 NULL")
+                    {
+                        CodeInstruction codeInstruction = new CodeInstruction(OpCodes.Ldsfld, AccessTools.Field(typeof(MainClass), "newPlayerCount"));
+                        newInstructions.Add(codeInstruction);
+                        alreadyReplaced = true;
+                        continue;
+                    }
                 }
 
                 newInstructions.Add(instruction);
             }
+
+            if (!alreadyReplaced) MainClass.StaticLogger.LogWarning("DressGirlHauntPatch failed to replace newPlayerCount");
 
             return newInstructions.AsEnumerable();
         }

--- a/MoreCompany/HudPatches.cs
+++ b/MoreCompany/HudPatches.cs
@@ -296,6 +296,8 @@ namespace MoreCompany
 				newInstructions.Add(instruction);
             }
 
+            if (!alreadyReplaced) MainClass.StaticLogger.LogWarning("KickPatch failed to replace newPlayerCount");
+
             return newInstructions.AsEnumerable();
         }
     }

--- a/MoreCompany/MainClass.cs
+++ b/MoreCompany/MainClass.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Reflection.Emit;
 using System.Text;
 using BepInEx;
+using BepInEx.Configuration;
 using BepInEx.Logging;
 using GameNetcodeStuff;
 using HarmonyLib;
@@ -30,7 +31,10 @@ namespace MoreCompany
         public static int newPlayerCount = 32;
         public static int minPlayerCount = 4;
         public static int maxPlayerCount = 50;
-        public static bool showCosmetics = true;
+
+        public static ConfigFile StaticConfig;
+        public static ConfigEntry<bool> showCosmetics;
+        public static ConfigEntry<bool> showCosmeticsForced;
 
         public static Texture2D mainLogo;
         public static GameObject quickMenuScrollParent;
@@ -53,8 +57,12 @@ namespace MoreCompany
         private void Awake()
         {
             StaticLogger = Logger;
-            Harmony harmony = new Harmony(PluginInformation.PLUGIN_GUID);
 
+            StaticConfig = Config;
+            showCosmetics = StaticConfig.Bind("Cosmetics", "Visibility", true, "Should cosmetics be visible to you?");
+            showCosmeticsForced = StaticConfig.Bind("Cosmetics", "Force Visibility", false, "Should the option above be forced? This will disable the UI button.");
+
+            Harmony harmony = new Harmony(PluginInformation.PLUGIN_GUID);
             try
             {
                 harmony.PatchAll();
@@ -144,7 +152,6 @@ namespace MoreCompany
         {
             string built = "";
             built += newPlayerCount + "\n";
-            built += showCosmetics + "\n";
             System.IO.File.WriteAllText(moreCompanySave, built);
         }
 
@@ -156,13 +163,11 @@ namespace MoreCompany
                 try
                 {
                     newPlayerCount = Mathf.Clamp(int.Parse(lines[0]), minPlayerCount, maxPlayerCount);
-                    showCosmetics = bool.Parse(lines[1]);
                 }
                 catch (Exception e)
                 {
                     StaticLogger.LogError("Failed to read settings from file, resetting to default");
                     newPlayerCount = 32;
-                    showCosmetics = true;
                 }
             }
         }

--- a/MoreCompany/MainClass.cs
+++ b/MoreCompany/MainClass.cs
@@ -52,7 +52,7 @@ namespace MoreCompany
         public static Dictionary<int, List<string>> playerIdsAndCosmetics = new Dictionary<int, List<string>>();
 
         public static string dynamicCosmeticsPath = Paths.PluginPath + "/MoreCompanyCosmetics";
-        public static string cosmeticSavePath = dynamicCosmeticsPath + "/enabled.log";
+        public static string cosmeticSavePath = Paths.BepInExRootPath + "/MCCosmeticsSave.log";
 
         private void Awake()
         {

--- a/MoreCompany/MainClass.cs
+++ b/MoreCompany/MainClass.cs
@@ -36,7 +36,6 @@ namespace MoreCompany
         public static ConfigFile StaticConfig;
         public static ConfigEntry<int> playerCount;
         public static ConfigEntry<bool> cosmeticsSyncOther;
-        public static ConfigEntry<bool> cosmeticsSyncHost;
         public static ConfigEntry<bool> defaultCosmetics;
 
         public static Texture2D mainLogo;
@@ -62,7 +61,6 @@ namespace MoreCompany
 
             playerCount = StaticConfig.Bind("General", "Player Count", defaultPlayerCount, new ConfigDescription("How many players can be in your lobby?", new AcceptableValueRange<int>(minPlayerCount, maxPlayerCount)));
             cosmeticsSyncOther = StaticConfig.Bind("Cosmetics", "Show Cosmetics", true, "Should you be able to see cosmetics of other players?"); // This is the one linked to the UI button
-            cosmeticsSyncHost = StaticConfig.Bind("Cosmetics", "Host Sync", true, "Disabling this prevents players in lobbies that you host from seeing any cosmetics.");
             defaultCosmetics = StaticConfig.Bind("Cosmetics", "Default Cosmetics", true, "Should the default cosmetics be enabled?");
 
             Harmony harmony = new Harmony(PluginInformation.PLUGIN_GUID);

--- a/MoreCompany/MainClass.cs
+++ b/MoreCompany/MainClass.cs
@@ -59,10 +59,10 @@ namespace MoreCompany
             StaticLogger = Logger;
 
             StaticConfig = Config;
+            cosmeticsSyncOther = StaticConfig.Bind("Cosmetics", "View Other Players Cosmetics", true, "Should you be able to see cosmetics of other players?"); // This is the one linked to the UI button
             cosmeticsSyncOwn = StaticConfig.Bind("Cosmetics", "Sync Own Cosmetics", true, "Should other players be able to see your cosmetics?");
-            cosmeticsSyncOther = StaticConfig.Bind("Cosmetics", "Enabled", true, "Should you be able to see cosmetics of other players?");
             cosmeticsSyncHost = StaticConfig.Bind("Cosmetics", "Host Sync", true, "This toggles whether cosmetics will sync between players in lobbies that you host.");
-            defaultCosmetics = StaticConfig.Bind("Cosmetics", "Default Cosmetics", true, "Should the default cosmetics be useable?");
+            defaultCosmetics = StaticConfig.Bind("Cosmetics", "Default Cosmetics", true, "Should the default cosmetics be usable?");
 
             Harmony harmony = new Harmony(PluginInformation.PLUGIN_GUID);
             try

--- a/MoreCompany/MainClass.cs
+++ b/MoreCompany/MainClass.cs
@@ -320,24 +320,21 @@ namespace MoreCompany
         private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {
             var newInstructions = new List<CodeInstruction>();
-            bool alreadyReplaced = false;
+            int alreadyReplaced = 0;
             foreach (var instruction in instructions)
             {
-                if (!alreadyReplaced)
+                if (instruction.ToString() == "ldc.i4.4 NULL")
                 {
-                    if (instruction.ToString() == "ldc.i4.4 NULL")
-                    {
-                        alreadyReplaced = true;
-                        CodeInstruction codeInstruction = new CodeInstruction(OpCodes.Ldsfld, AccessTools.Field(typeof(MainClass), "newPlayerCount"));
-                        newInstructions.Add(codeInstruction);
-                        continue;
-                    }
+                    alreadyReplaced++;
+                    CodeInstruction codeInstruction = new CodeInstruction(OpCodes.Ldsfld, AccessTools.Field(typeof(MainClass), "newPlayerCount"));
+                    newInstructions.Add(codeInstruction);
+                    continue;
                 }
 
                 newInstructions.Add(instruction);
             }
 
-            if (!alreadyReplaced) MainClass.StaticLogger.LogWarning("SyncAllPlayerLevelsPatch failed to replace newPlayerCount");
+            if (alreadyReplaced != 2) MainClass.StaticLogger.LogWarning($"SyncAllPlayerLevelsPatch failed to replace newPlayerCount: {alreadyReplaced}/2");
 
             return newInstructions.AsEnumerable();
         }
@@ -375,7 +372,7 @@ namespace MoreCompany
                 newInstructions.Add(instruction);
             }
 
-            if (alreadyReplaced != 2) MainClass.StaticLogger.LogWarning("SyncShipUnlockablesServerRpc failed to replace newPlayerCount");
+            if (alreadyReplaced != 2) MainClass.StaticLogger.LogWarning($"SyncShipUnlockablesServerRpc failed to replace newPlayerCount: {alreadyReplaced}/2");
 
             return newInstructions.AsEnumerable();
         }

--- a/MoreCompany/MimicPatches.cs
+++ b/MoreCompany/MimicPatches.cs
@@ -15,7 +15,7 @@ namespace MoreCompany
         {
             public static void Postfix(ref MaskedPlayerEnemy __instance)
             {
-                if (__instance.mimickingPlayer != null && MainClass.showCosmetics.Value)
+                if (__instance.mimickingPlayer != null && MainClass.cosmeticsSyncOther.Value)
                 {
                     List<string> cosmetics = MainClass.playerIdsAndCosmetics[(int)__instance.mimickingPlayer.playerClientId];
                     Transform cosmeticRoot = __instance.transform.Find("ScavengerModel").Find("metarig");

--- a/MoreCompany/MimicPatches.cs
+++ b/MoreCompany/MimicPatches.cs
@@ -15,7 +15,7 @@ namespace MoreCompany
         {
             public static void Postfix(ref MaskedPlayerEnemy __instance)
             {
-                if (__instance.mimickingPlayer != null && MainClass.cosmeticsSyncOther.Value)
+                if (__instance.mimickingPlayer != null && MainClass.cosmeticsSyncOther.Value && MainClass.playerIdsAndCosmetics.ContainsKey((int)__instance.mimickingPlayer.playerClientId))
                 {
                     List<string> cosmetics = MainClass.playerIdsAndCosmetics[(int)__instance.mimickingPlayer.playerClientId];
                     Transform cosmeticRoot = __instance.transform.Find("ScavengerModel").Find("metarig");

--- a/MoreCompany/MimicPatches.cs
+++ b/MoreCompany/MimicPatches.cs
@@ -15,7 +15,7 @@ namespace MoreCompany
         {
             public static void Postfix(ref MaskedPlayerEnemy __instance)
             {
-                if (__instance.mimickingPlayer != null && MainClass.showCosmetics)
+                if (__instance.mimickingPlayer != null && MainClass.showCosmetics.Value)
                 {
                     List<string> cosmetics = MainClass.playerIdsAndCosmetics[(int)__instance.mimickingPlayer.playerClientId];
                     Transform cosmeticRoot = __instance.transform.Find("ScavengerModel").Find("metarig");

--- a/MoreCompany/SpectatePatches.cs
+++ b/MoreCompany/SpectatePatches.cs
@@ -12,10 +12,12 @@ namespace MoreCompany
         private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {
             var newInstructions = new List<CodeInstruction>();
+            bool alreadyReplaced = false;
             foreach (var instruction in instructions)
             {
                 if (instruction.ToString() == "ldc.i4.4 NULL")
                 {
+                    alreadyReplaced = true;
                     CodeInstruction codeInstruction = new CodeInstruction(OpCodes.Ldsfld, AccessTools.Field(typeof(MainClass), "newPlayerCount"));
                     newInstructions.Add(codeInstruction);
                     continue;
@@ -23,6 +25,8 @@ namespace MoreCompany
 
                 newInstructions.Add(instruction);
             }
+
+            if (!alreadyReplaced) MainClass.StaticLogger.LogWarning("SpectateNextPlayer failed to replace newPlayerCount");
 
             return newInstructions.AsEnumerable();
         }

--- a/MoreCompany/SpectatePatches.cs
+++ b/MoreCompany/SpectatePatches.cs
@@ -12,12 +12,12 @@ namespace MoreCompany
         private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {
             var newInstructions = new List<CodeInstruction>();
-            bool alreadyReplaced = false;
+            int alreadyReplaced = 0;
             foreach (var instruction in instructions)
             {
                 if (instruction.ToString() == "ldc.i4.4 NULL")
                 {
-                    alreadyReplaced = true;
+                    alreadyReplaced++;
                     CodeInstruction codeInstruction = new CodeInstruction(OpCodes.Ldsfld, AccessTools.Field(typeof(MainClass), "newPlayerCount"));
                     newInstructions.Add(codeInstruction);
                     continue;
@@ -26,7 +26,7 @@ namespace MoreCompany
                 newInstructions.Add(instruction);
             }
 
-            if (!alreadyReplaced) MainClass.StaticLogger.LogWarning("SpectateNextPlayer failed to replace newPlayerCount");
+            if (alreadyReplaced != 2) MainClass.StaticLogger.LogWarning($"SpectateNextPlayer failed to replace newPlayerCount: {alreadyReplaced}/2");
 
             return newInstructions.AsEnumerable();
         }

--- a/MoreCompany/StartPatches.cs
+++ b/MoreCompany/StartPatches.cs
@@ -81,4 +81,16 @@ namespace MoreCompany
             return newInstructions.AsEnumerable();
         }
     }
+
+    [HarmonyPatch(typeof(StartOfRound), "OnPlayerDC")]
+    public static class OnPlayerDCPatch
+    {
+        public static void Postfix(int playerObjectNumber, ulong clientId)
+        {
+            if (MainClass.playerIdsAndCosmetics.ContainsKey(playerObjectNumber))
+            {
+                MainClass.playerIdsAndCosmetics.Remove(playerObjectNumber);
+            }
+        }
+    }
 }

--- a/MoreCompany/StartPatches.cs
+++ b/MoreCompany/StartPatches.cs
@@ -19,7 +19,7 @@ namespace MoreCompany
             Array.Resize(ref __instance.playerVoiceVolumes, MainClass.newPlayerCount);
             Array.Resize(ref __instance.playerVoiceMixers, MainClass.newPlayerCount);
 
-            AudioMixerGroup audioMixerGroup = Resources.FindObjectsOfTypeAll<AudioMixerGroup>().FirstOrDefault(x => x.name.Contains("Voice"));
+            AudioMixerGroup audioMixerGroup = Resources.FindObjectsOfTypeAll<AudioMixerGroup>().FirstOrDefault(x => x.name.StartsWith("VoicePlayer"));
             for (int i = 0; i < MainClass.newPlayerCount; i++)
             {
                 __instance.playerVoicePitchLerpSpeed[i] = 3f;
@@ -28,7 +28,9 @@ namespace MoreCompany
                 __instance.playerVoiceVolumes[i] = 0.5f;
 				if (!__instance.playerVoiceMixers[i])
 				{
-					__instance.playerVoiceMixers[i] = audioMixerGroup;
+                    AudioMixerGroup newAudioMixerGroup = GameObject.Instantiate(audioMixerGroup);
+                    newAudioMixerGroup.name = $"VoicePlayer{i}";
+                    __instance.playerVoiceMixers[i] = newAudioMixerGroup;
 				}
             }
         }
@@ -73,6 +75,8 @@ namespace MoreCompany
 
 				newInstructions.Add(instruction);
             }
+
+            if (!alreadyReplaced) MainClass.StaticLogger.LogWarning("OnClientConnect failed to replace newPlayerCount");
 
             return newInstructions.AsEnumerable();
         }


### PR DESCRIPTION
- Fixed cosmetics that you had enabled but removed the file for still being synced to other players (with the original code if they have the cosmetic enabled however you don't, they'd still see you wearing it).
- Made the list of enabled cosmetics be stored per-profile (MCCosmeticsSave.log in the BepInEx folder - it's a .log file so it doesn't sync when sharing a profile via R2MM/TMM).
- Made last player count be stored in LCGeneralSaveData instead of morecompanysave.txt noting it would've been the only thing saved to the file so kinda pointless storing it separate now.
- Added a bunch of config options for cosmetics.
  * Ability to disable the default cosmetics.
  * Ability to disable you seeing the cosmetics of other players.

The reasoning behind the additional configuration is to allow modpacks to have more configurability such as disabling cosmetics by default if they use a different mod for cosmetics or if they just want to disable the original cosmetics and only use custom ones.