### PR TITLE
Crew Limit Fixes

### DIFF
--- a/MoreCompany/HudPatches.cs
+++ b/MoreCompany/HudPatches.cs
@@ -92,30 +92,39 @@ namespace MoreCompany
             inputField.characterLimit = 3;
             inputField.text = MainClass.newPlayerCount.ToString();
             inputFields.Add(inputField);
-            inputField.onValueChanged.AddListener(s =>
-            {
-                if (inputField.text == MainClass.newPlayerCount.ToString())
-                    return;
-
-                if (int.TryParse(s, out int result))
-                {
-                    MainClass.newPlayerCount = Mathf.Clamp(result, MainClass.minPlayerCount, MainClass.maxPlayerCount);
-                    foreach(TMP_InputField field in inputFields)
-                        field.text = MainClass.newPlayerCount.ToString();
-                    MainClass.SaveSettingsToFile();
-                    MainClass.StaticLogger.LogInfo($"Changed Crew Count: {MainClass.newPlayerCount}");
-                }
-                else if (s.Length != 0)
-                {
-                    foreach (TMP_InputField field in inputFields)
-                    {
-                        field.text = MainClass.newPlayerCount.ToString();
-                        field.caretPosition = 1;
-                    }
-                }
+            inputField.onSubmit.AddListener(s => {
+                UpdateTextBox(inputField, s);
+            });
+            inputField.onDeselect.AddListener(s => {
+                UpdateTextBox(inputField, s);
             });
         }
-	}
+
+        public static void UpdateTextBox(TMP_InputField inputField, string s)
+        {
+            if (inputField.text == MainClass.newPlayerCount.ToString())
+                return;
+
+            if (int.TryParse(s, out int result))
+            {
+                int originalCount = MainClass.newPlayerCount;
+                MainClass.newPlayerCount = Mathf.Clamp(result, MainClass.minPlayerCount, MainClass.maxPlayerCount);
+                foreach (TMP_InputField field in inputFields)
+                    field.text = MainClass.newPlayerCount.ToString();
+                MainClass.SaveSettingsToFile();
+                if (MainClass.newPlayerCount != originalCount)
+                    MainClass.StaticLogger.LogInfo($"Changed Crew Count: {MainClass.newPlayerCount}");
+            }
+            else if (s.Length != 0)
+            {
+                foreach (TMP_InputField field in inputFields)
+                {
+                    field.text = MainClass.newPlayerCount.ToString();
+                    field.caretPosition = 1;
+                }
+            }
+        }
+    }
 
 	[HarmonyPatch(typeof(QuickMenuManager), "AddUserToPlayerList")]
 	public static class AddUserPlayerListPatch

--- a/MoreCompany/LANMenu.cs
+++ b/MoreCompany/LANMenu.cs
@@ -148,19 +148,22 @@ namespace MoreCompany
             {
                 MainClass.newPlayerCount = Mathf.Clamp(crewSizeMismatch, MainClass.minPlayerCount, MainClass.maxPlayerCount);
 
-                GameObject.Find("MenuManager").GetComponent<MenuManager>().menuNotification.SetActive(false);
+                if (MainClass.newPlayerCount == crewSizeMismatch)
+                {
+                    GameObject.Find("MenuManager").GetComponent<MenuManager>().menuNotification.SetActive(false);
 
-                // Automatic Reconnect
-                Object.FindObjectOfType<MenuManager>().SetLoadingScreen(isLoading: true);
-                __instance.StartCoroutine(delayedReconnect());
+                    // Automatic Reconnect
+                    Object.FindObjectOfType<MenuManager>().SetLoadingScreen(isLoading: true);
+                    __instance.StartCoroutine(delayedReconnect());
 
-                //// Manual Reconnect
-                //foreach (TMP_InputField field in MenuManagerLogoOverridePatch.inputFields)
-                //    field.text = MainClass.newPlayerCount.ToString();
-                //TextMeshProUGUI footerText = GameObject.Find("Canvas/MenuContainer/LobbyJoinSettings/JoinSettingsContainer/PrivatePublicDescription").GetComponent<TextMeshProUGUI>();
-                //if (footerText != null)
-                //    footerText.text = $"The crew size was mismatched and has automatically been changed to {crewSizeMismatch}. Please re-attempt the connection.";
-                //GameObject.Find("Canvas/MenuContainer/LobbyJoinSettings").gameObject.SetActive(true);
+                    //// Manual Reconnect
+                    //foreach (TMP_InputField field in MenuManagerLogoOverridePatch.inputFields)
+                    //    field.text = MainClass.newPlayerCount.ToString();
+                    //TextMeshProUGUI footerText = GameObject.Find("Canvas/MenuContainer/LobbyJoinSettings/JoinSettingsContainer/PrivatePublicDescription").GetComponent<TextMeshProUGUI>();
+                    //if (footerText != null)
+                    //    footerText.text = $"The crew size was mismatched and has automatically been changed to {crewSizeMismatch}. Please re-attempt the connection.";
+                    //GameObject.Find("Canvas/MenuContainer/LobbyJoinSettings").gameObject.SetActive(true);
+                }
 
                 crewSizeMismatch = 0;
             }


### PR DESCRIPTION
- Fixed infinite loop when attempting to connect in LAN if crew limit is below 4 or higher than 50.
- Fixed being unable to type below 4 or above 50 in the crew limit (mainly an issue when trying to set it between 10 - 39).
  * It now saves when clicking off or pressing enter instead of when it's typed.