### PR TITLE
Made version be calculated from original version

### DIFF
--- a/MoreCompany/VersionPatches.cs
+++ b/MoreCompany/VersionPatches.cs
@@ -28,7 +28,7 @@ namespace MoreCompany
             // LC_API compatibility.
             if (!BepInEx.Bootstrap.Chainloader.PluginInfos.ContainsKey("LC_API"))
             {
-	            __instance.gameVersionNum = 9999;
+	            __instance.gameVersionNum = 9950 + originalVersion;
             }
         }
     }


### PR DESCRIPTION
- Made version be calculated from original version instead of all game versions being bulked into v9999 (v49 will still be equal to 9999).