### PR TITLE
Cosmetic Save File Fixes

### DIFF
--- a/MoreCompany/MainClass.cs
+++ b/MoreCompany/MainClass.cs
@@ -37,6 +37,7 @@ namespace MoreCompany
         public static ConfigEntry<int> playerCount;
         public static ConfigEntry<bool> cosmeticsSyncOther;
         public static ConfigEntry<bool> defaultCosmetics;
+        public static ConfigEntry<bool> cosmeticsPerProfile;
 
         public static Texture2D mainLogo;
         public static GameObject quickMenuScrollParent;
@@ -62,6 +63,7 @@ namespace MoreCompany
             playerCount = StaticConfig.Bind("General", "Player Count", defaultPlayerCount, new ConfigDescription("How many players can be in your lobby?", new AcceptableValueRange<int>(minPlayerCount, maxPlayerCount)));
             cosmeticsSyncOther = StaticConfig.Bind("Cosmetics", "Show Cosmetics", true, "Should you be able to see cosmetics of other players?"); // This is the one linked to the UI button
             defaultCosmetics = StaticConfig.Bind("Cosmetics", "Default Cosmetics", true, "Should the default cosmetics be enabled?");
+            cosmeticsPerProfile = StaticConfig.Bind("Cosmetics", "Per Profile Cosmetics", false, "Should the cosmetics be saved per-profile?");
 
             Harmony harmony = new Harmony(PluginInformation.PLUGIN_GUID);
             try
@@ -89,7 +91,25 @@ namespace MoreCompany
             ReadSettingsFromFile();
 
             dynamicCosmeticsPath = Paths.PluginPath + "/MoreCompanyCosmetics";
-            cosmeticSavePath = Paths.BepInExRootPath + "/MCCosmeticsSave.log";
+
+            if (cosmeticsPerProfile.Value)
+            {
+                cosmeticSavePath = $"{Application.persistentDataPath}/morecompanycosmetics-{Directory.GetParent(Paths.BepInExRootPath).Name}.txt";
+            }
+            else
+            {
+                cosmeticSavePath = $"{Application.persistentDataPath}/morecompanycosmetics.txt";
+            }
+            cosmeticsPerProfile.SettingChanged += (sender, args) => {
+                if (cosmeticsPerProfile.Value)
+                {
+                    cosmeticSavePath = $"{Application.persistentDataPath}/MCCosmeticsSave-{Directory.GetParent(Paths.BepInExRootPath).Name}.mcs";
+                }
+                else
+                {
+                    cosmeticSavePath = $"{Application.persistentDataPath}/MCCosmeticsSave.mcs";
+                }
+            };
 
             StaticLogger.LogInfo("Checking: " + dynamicCosmeticsPath);
             if (!Directory.Exists(dynamicCosmeticsPath))


### PR DESCRIPTION
- Fixed saved cosmetics being overwritten when reimporting a profile using r2modman/thunderstore mod manager.
- Added a config option to disable per-profile cosmetics.