### PR TITLE
Audio Fixes

### DIFF
--- a/MoreCompany/AudioMixerPatches.cs
+++ b/MoreCompany/AudioMixerPatches.cs
@@ -10,6 +10,8 @@ namespace MoreCompany
     {
         public static bool Prefix(string name, float value)
         {
+            if (MainClass.newPlayerCount <= 4 && name.StartsWith("PlayerPitch")) return true;
+
             if (name.StartsWith("PlayerVolume") || name.StartsWith("PlayerPitch"))
             {
                 string cutName = name.Replace("PlayerVolume", "").Replace("PlayerPitch", "");

--- a/MoreCompany/HudPatches.cs
+++ b/MoreCompany/HudPatches.cs
@@ -239,15 +239,15 @@ namespace MoreCompany
                     {
                         if (playerScript.isPlayerControlled || playerScript.isPlayerDead)
                         {
-                            float num = (f / playerVolume.maxValue) + 1f;
-                            if (num <= -1f)
+                            float num = (f - playerVolume.minValue) / (playerVolume.maxValue - playerVolume.minValue);
+                            if (num <= 0f)
                             {
                                 num = -70f;
                             }
                             SoundManager.Instance.playerVoiceVolumes[finalIndex] = num;
                         }
                     });
-                    playerVolume.value = Math.Clamp((SoundManager.Instance.playerVoiceVolumes[i] - 1) * playerVolume.maxValue, playerVolume.minValue, playerVolume.maxValue);
+                    playerVolume.value = Math.Clamp((SoundManager.Instance.playerVoiceVolumes[i] * (playerVolume.maxValue - playerVolume.minValue)) + playerVolume.minValue, playerVolume.minValue, playerVolume.maxValue);
 
                     Button kickButton = spawnedPlayer.transform.Find("KickButton").GetComponent<Button>();
                     kickButton.onClick.AddListener(() =>


### PR DESCRIPTION
- Fixed volume slider setting the player volume to a value between 0-2 when it should be between 0-1.
- Fixed pitch not working in lobbies that are maxed at 4 players.
  - Some people only use MoreCompany for cosmetics so there's no reason to break the pitch for them.