### PR TITLE
Fixed Volume Issues

### DIFF
--- a/MoreCompany/MainClass.cs
+++ b/MoreCompany/MainClass.cs
@@ -558,6 +558,7 @@ namespace MoreCompany
         private static void OnPlayerConnectedClientRpc(StartOfRound __instance, ulong clientId, int connectedPlayers, ulong[] connectedPlayerIdsOrdered, int assignedPlayerObjectId, int serverMoneyAmount, int levelID, int profitQuota, int timeUntilDeadline, int quotaFulfilled, int randomSeed, bool isChallenge)
         {
             __instance.allPlayerScripts[assignedPlayerObjectId].gameObject.SetActive(true);
+            SoundManager.Instance.playerVoiceVolumes[assignedPlayerObjectId] = SoundManagerPatch.defaultPlayerVolume;
         }
 
         [HarmonyPatch(typeof(StartOfRound), "OnPlayerDC")]

--- a/MoreCompany/StartPatches.cs
+++ b/MoreCompany/StartPatches.cs
@@ -8,11 +8,25 @@ using OpCodes = System.Reflection.Emit.OpCodes;
 
 namespace MoreCompany
 {
-    [HarmonyPatch(typeof(SoundManager), "Start")]
-    public static class SoundManagerStartPatch
+    [HarmonyPatch]
+    public static class SoundManagerPatch
     {
-        public static void Postfix(ref SoundManager __instance)
+        internal const float defaultPlayerVolume = 0.5f;
+        internal static bool initialVolumeSet = false;
+
+        [HarmonyPatch(typeof(SoundManager), "Start")]
+        [HarmonyPostfix]
+        public static void SM_Start(ref SoundManager __instance)
         {
+            // Set the vanilla diageticMixer volumes for all player controllers to max
+            initialVolumeSet = false;
+            float defaultVolume = 16f;
+            __instance.diageticMixer.SetFloat("PlayerVolume0", defaultVolume);
+            __instance.diageticMixer.SetFloat("PlayerVolume1", defaultVolume);
+            __instance.diageticMixer.SetFloat("PlayerVolume2", defaultVolume);
+            __instance.diageticMixer.SetFloat("PlayerVolume3", defaultVolume);
+            initialVolumeSet = true;
+
             Array.Resize(ref __instance.playerVoicePitchLerpSpeed, MainClass.newPlayerCount);
             Array.Resize(ref __instance.playerVoicePitchTargets, MainClass.newPlayerCount);
             Array.Resize(ref __instance.playerVoicePitches, MainClass.newPlayerCount);
@@ -25,7 +39,7 @@ namespace MoreCompany
                 __instance.playerVoicePitchLerpSpeed[i] = 3f;
                 __instance.playerVoicePitchTargets[i] = 1f;
                 __instance.playerVoicePitches[i] = 1f;
-                __instance.playerVoiceVolumes[i] = 0.5f;
+                __instance.playerVoiceVolumes[i] = defaultPlayerVolume;
 				if (!__instance.playerVoiceMixers[i])
 				{
                     __instance.playerVoiceMixers[i] = audioMixerGroup;


### PR DESCRIPTION
- Fixed voice volume for newly joined players defaulting to 100% instead of 50% for players that were already in the lobby
  - This is due to `SoundManager.SetPlayerVoiceFilters` setting the volume to `1` if the player isn't controlled and isn't dead however it's never reset back to the morecompany default of 0.5
- Fixed max voice volume not being as loud as vanilla
  - The default volume of the player volume diagetic mixer groups in vanilla is 4 however the max volume in vanilla is 16 so I've changed it to increase the diagetic mixer group volumes to 16 instead of leaving it untouched