### PR TITLE
LAN Lobby List

### DIFF
--- a/MoreCompany/ChatPatches.cs
+++ b/MoreCompany/ChatPatches.cs
@@ -30,7 +30,7 @@ namespace MoreCompany
     public static class CosmeticSyncPatch
     {
         // This method runs whenever a player's cosmetics are updated
-        public static void UpdateCosmeticsForPlayer(int playerClientId, List<string> splitMessage, bool showOwnCosmetics = false)
+        public static void UpdateCosmeticsForPlayer(int playerClientId, List<string> splitMessage)
         {
             CosmeticApplication cosmeticApplication = StartOfRound.Instance.allPlayerScripts[playerClientId].transform.Find("ScavengerModel")
                 .Find("metarig").gameObject.GetComponent<CosmeticApplication>();
@@ -41,24 +41,24 @@ namespace MoreCompany
                 .Find("metarig").gameObject.AddComponent<CosmeticApplication>();
             }
 
-            cosmeticApplication.ClearCosmetics();
+            cosmeticApplication.parentType = ParentType.Player;
 
+            cosmeticApplication.ClearCosmetics();
             List<string> cosmeticsToApply = new List<string>();
             foreach (string cosmeticId in splitMessage)
             {
-                cosmeticsToApply.Add(cosmeticId);
-                cosmeticApplication.ApplyCosmetic(cosmeticId, MainClass.cosmeticsSyncOther.Value);
-            }
-
-            if (playerClientId == StartOfRound.Instance.thisClientPlayerId && !showOwnCosmetics)
-            {
-                cosmeticApplication.ClearCosmetics();
+                if (cosmeticApplication.ApplyCosmetic(cosmeticId, false))
+                {
+                    cosmeticsToApply.Add(cosmeticId);
+                }
             }
 
             foreach (var cosmeticSpawned in cosmeticApplication.spawnedCosmetics)
             {
                 cosmeticSpawned.transform.localScale *= CosmeticRegistry.COSMETIC_PLAYER_SCALE_MULT;
             }
+
+            cosmeticApplication.UpdateAllCosmeticVisibilities(playerClientId == StartOfRound.Instance.thisClientPlayerId);
 
             if (MainClass.playerIdsAndCosmetics.ContainsKey(playerClientId))
             {

--- a/MoreCompany/Compatibility/LobbyCompatibility.cs
+++ b/MoreCompany/Compatibility/LobbyCompatibility.cs
@@ -1,0 +1,18 @@
+using System;
+using LobbyCompatibility.Enums;
+using LobbyCompatibility.Features;
+
+namespace MoreCompany.Compatibility
+{
+    internal class LobbyCompatibility
+    {
+        public static void Init()
+        {
+            MainClass.StaticLogger.LogWarning("LobbyCompatibility detected, registering plugin with LobbyCompatibility.");
+
+            Version pluginVersion = Version.Parse(PluginInformation.PLUGIN_VERSION);
+
+            PluginHelper.RegisterPlugin(PluginInformation.PLUGIN_GUID, pluginVersion, CompatibilityLevel.Everyone, VersionStrictness.Minor);
+        }
+    }
+}

--- a/MoreCompany/CosmeticPatches.cs
+++ b/MoreCompany/CosmeticPatches.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using GameNetcodeStuff;
 using HarmonyLib;
 using MoreCompany.Cosmetics;
@@ -10,29 +9,33 @@ namespace MoreCompany
     [HarmonyPatch]
     public class CosmeticPatches
     {
-        public static bool CloneCosmeticsToNonPlayer(Transform cosmeticRoot, int playerClientId, bool detachedHead = false, bool startEnabled = true)
+        public static bool CloneCosmeticsToNonPlayer(ParentType parentType, Transform cosmeticRoot, int playerClientId, bool detachedHead = false)
         {
             if (MainClass.playerIdsAndCosmetics.ContainsKey(playerClientId))
             {
                 List<string> cosmetics = MainClass.playerIdsAndCosmetics[playerClientId];
                 CosmeticApplication cosmeticApplication = cosmeticRoot.GetComponent<CosmeticApplication>();
-                if (cosmeticApplication)
+
+                if (!cosmeticApplication)
                 {
-                    cosmeticApplication.ClearCosmetics();
-                    GameObject.Destroy(cosmeticApplication);
+                    cosmeticApplication = cosmeticRoot.gameObject.AddComponent<CosmeticApplication>();
                 }
 
-                cosmeticApplication = cosmeticRoot.gameObject.AddComponent<CosmeticApplication>();
+                cosmeticApplication.parentType = parentType;
                 cosmeticApplication.detachedHead = detachedHead;
-                foreach (var cosmetic in cosmetics)
+
+                cosmeticApplication.ClearCosmetics();
+                foreach (var cosmeticId in cosmetics)
                 {
-                    cosmeticApplication.ApplyCosmetic(cosmetic, startEnabled);
+                    cosmeticApplication.ApplyCosmetic(cosmeticId, false);
                 }
 
                 foreach (var cosmetic in cosmeticApplication.spawnedCosmetics)
                 {
                     cosmetic.transform.localScale *= CosmeticRegistry.COSMETIC_PLAYER_SCALE_MULT;
                 }
+
+                cosmeticApplication.UpdateAllCosmeticVisibilities(false);
 
                 return true;
             }
@@ -48,7 +51,7 @@ namespace MoreCompany
             if (cosmeticRoot == null) return;
             bool detachedHead = __instance.deadBody.detachedHead;
             if (deathAnimation == 4 || deathAnimation == 5) detachedHead = true; // Masked
-            CloneCosmeticsToNonPlayer(cosmeticRoot, (int)__instance.playerClientId, detachedHead: detachedHead, startEnabled: MainClass.cosmeticsDeadBodies.Value);
+            CloneCosmeticsToNonPlayer(ParentType.DeadBody, cosmeticRoot, (int)__instance.playerClientId, detachedHead: detachedHead);
         }
 
         // "Why this function? Why not Start/Awake/Another function?" Well, Start and Awake are called on clients that arent the host before the mimicking player is set.
@@ -60,7 +63,7 @@ namespace MoreCompany
             if (__instance.mimickingPlayer == null) return;
             Transform cosmeticRoot = __instance.transform.Find("ScavengerModel").Find("metarig");
             if (cosmeticRoot == null) return;
-            CloneCosmeticsToNonPlayer(cosmeticRoot, (int)__instance.mimickingPlayer.playerClientId, detachedHead: false, startEnabled: MainClass.cosmeticsMaskedEnemy.Value);
+            CloneCosmeticsToNonPlayer(ParentType.MaskedEnemy, cosmeticRoot, (int)__instance.mimickingPlayer.playerClientId, detachedHead: false);
             __instance.skinnedMeshRenderers = __instance.gameObject.GetComponentsInChildren<SkinnedMeshRenderer>();
             __instance.meshRenderers = __instance.gameObject.GetComponentsInChildren<MeshRenderer>();
         }

--- a/MoreCompany/Cosmetics/CosmeticApplication.cs
+++ b/MoreCompany/Cosmetics/CosmeticApplication.cs
@@ -1,12 +1,22 @@
+using GameNetcodeStuff;
 using System;
 using System.Collections.Generic;
 using UnityEngine;
 
 namespace MoreCompany.Cosmetics
 {
+    public enum ParentType
+    {
+        Player,
+        DeadBody,
+        MaskedEnemy,
+    }
+
     public class CosmeticApplication : MonoBehaviour
     {
         public bool detachedHead = false;
+
+        public ParentType parentType;
 
         public Transform head;
         public Transform hip;
@@ -15,6 +25,7 @@ namespace MoreCompany.Cosmetics
         public Transform shinRight;
         public Transform chest;
         public List<CosmeticInstance> spawnedCosmetics = new List<CosmeticInstance>();
+        public List<string> spawnedCosmeticsIds = new List<string>();
 
         public void Awake()
         {
@@ -39,10 +50,28 @@ namespace MoreCompany.Cosmetics
 
         private void OnEnable()
         {
-            foreach (var spawnedCosmetic in spawnedCosmetics)
+            if (spawnedCosmetics.Count > 0)
             {
-                if (spawnedCosmetic.cosmeticType == CosmeticType.HAT && detachedHead) continue;
-                spawnedCosmetic.gameObject.SetActive(true);
+                if (parentType == ParentType.Player)
+                {
+                    PlayerControllerB playerController = transform.GetComponentInParent<PlayerControllerB>();
+                    UpdateAllCosmeticVisibilities(playerController != null && (int)playerController.playerClientId == StartOfRound.Instance.thisClientPlayerId);
+                }
+                else if (parentType == ParentType.MaskedEnemy)
+                {
+                    UpdateAllCosmeticVisibilities();
+
+                    MaskedPlayerEnemy maskedEnemy = transform.GetComponentInParent<MaskedPlayerEnemy>();
+                    if (maskedEnemy != null)
+                    {
+                        maskedEnemy.skinnedMeshRenderers = maskedEnemy.gameObject.GetComponentsInChildren<SkinnedMeshRenderer>();
+                        maskedEnemy.meshRenderers = maskedEnemy.gameObject.GetComponentsInChildren<MeshRenderer>();
+                    }
+                }
+                else
+                {
+                    UpdateAllCosmeticVisibilities();
+                }
             }
         }
 
@@ -53,24 +82,55 @@ namespace MoreCompany.Cosmetics
                 GameObject.Destroy(spawnedCosmetic.gameObject);
             }
             spawnedCosmetics.Clear();
+            spawnedCosmeticsIds.Clear();
         }
         
-        public void ApplyCosmetic(string cosmeticId, bool startEnabled)
+        public bool ApplyCosmetic(string cosmeticId, bool startEnabled)
         {
-            if (CosmeticRegistry.cosmeticInstances.ContainsKey(cosmeticId))
+            if (CosmeticRegistry.cosmeticInstances.ContainsKey(cosmeticId) && !spawnedCosmeticsIds.Contains(cosmeticId))
             {
                 CosmeticInstance cosmeticInstance = CosmeticRegistry.cosmeticInstances[cosmeticId];
 
-                if (startEnabled && cosmeticInstance.cosmeticType == CosmeticType.HAT && detachedHead) return;
+                if (startEnabled && cosmeticInstance.cosmeticType == CosmeticType.HAT && detachedHead) return false;
 
                 GameObject cosmeticInstanceGameObject = GameObject.Instantiate(cosmeticInstance.gameObject);
                 cosmeticInstanceGameObject.SetActive(startEnabled);
                 CosmeticInstance cosmeticInstanceBehavior = cosmeticInstanceGameObject.GetComponent<CosmeticInstance>();
                 spawnedCosmetics.Add(cosmeticInstanceBehavior);
                 ParentCosmetic(cosmeticInstanceBehavior);
+                spawnedCosmeticsIds.Add(cosmeticId);
+                return true;
+            }
+
+            return false;
+        }
+
+        public void UpdateAllCosmeticVisibilities(bool isLocalPlayer = false)
+        {
+            bool isActive = false;
+            if (parentType == ParentType.Player)
+            {
+                isActive = MainClass.cosmeticsSyncOther.Value && !isLocalPlayer;
+                MainClass.StaticLogger.LogInfo("UpdateAllCosmeticVisibilities: PlayerControllerB");
+            }
+            else if (parentType == ParentType.DeadBody)
+            {
+                isActive = MainClass.cosmeticsDeadBodies.Value;
+                MainClass.StaticLogger.LogInfo("UpdateAllCosmeticVisibilities: DeadBodyInfo");
+            }
+            else if (parentType == ParentType.MaskedEnemy)
+            {
+                isActive = MainClass.cosmeticsMaskedEnemy.Value;
+                MainClass.StaticLogger.LogInfo("UpdateAllCosmeticVisibilities: MaskedPlayerEnemy");
+            }
+
+            foreach (var spawnedCosmetic in spawnedCosmetics)
+            {
+                if (spawnedCosmetic.cosmeticType == CosmeticType.HAT && detachedHead) continue;
+                spawnedCosmetic.gameObject.SetActive(isActive);
             }
         }
-        
+
         public void RefreshAllCosmeticPositions()
         {
             foreach (var spawnedCosmetic in spawnedCosmetics)
@@ -79,7 +139,7 @@ namespace MoreCompany.Cosmetics
             }
         }
 
-        private void ParentCosmetic(CosmeticInstance cosmeticInstance)
+        private bool ParentCosmetic(CosmeticInstance cosmeticInstance)
         {
             Transform targetTransform = null;
             switch (cosmeticInstance.cosmeticType)
@@ -107,12 +167,13 @@ namespace MoreCompany.Cosmetics
             if (targetTransform == null)
             {
                 MainClass.StaticLogger.LogError("Failed to find transform of type: " + cosmeticInstance.cosmeticType);
-                return;
+                return false;
             }
 
             cosmeticInstance.transform.position = targetTransform.position;
             cosmeticInstance.transform.rotation = targetTransform.rotation;
             cosmeticInstance.transform.parent = targetTransform;
+            return true;
         }
     }
 }

--- a/MoreCompany/Cosmetics/CosmeticApplication.cs
+++ b/MoreCompany/Cosmetics/CosmeticApplication.cs
@@ -111,17 +111,14 @@ namespace MoreCompany.Cosmetics
             if (parentType == ParentType.Player)
             {
                 isActive = MainClass.cosmeticsSyncOther.Value && !isLocalPlayer;
-                MainClass.StaticLogger.LogInfo("UpdateAllCosmeticVisibilities: PlayerControllerB");
             }
             else if (parentType == ParentType.DeadBody)
             {
                 isActive = MainClass.cosmeticsDeadBodies.Value;
-                MainClass.StaticLogger.LogInfo("UpdateAllCosmeticVisibilities: DeadBodyInfo");
             }
             else if (parentType == ParentType.MaskedEnemy)
             {
                 isActive = MainClass.cosmeticsMaskedEnemy.Value;
-                MainClass.StaticLogger.LogInfo("UpdateAllCosmeticVisibilities: MaskedPlayerEnemy");
             }
 
             foreach (var spawnedCosmetic in spawnedCosmetics)

--- a/MoreCompany/HudPatches.cs
+++ b/MoreCompany/HudPatches.cs
@@ -133,7 +133,7 @@ namespace MoreCompany
 
             try
             {
-                LANMenu.InitializeMenu();
+                InitializeMenu();
             }
             catch (Exception e)
             {
@@ -141,6 +141,82 @@ namespace MoreCompany
             }
 
             CosmeticRegistry.SpawnCosmeticGUI(true);
+        }
+
+        public static void InitializeMenu()
+        {
+            var startLAN_button = GameObject.Find("Canvas/MenuContainer/MainButtons/StartLAN");
+            if (startLAN_button != null)
+            {
+                MainClass.StaticLogger.LogInfo("LANMenu startLAN Patched");
+                startLAN_button.GetComponent<Button>().onClick = new Button.ButtonClickedEvent();
+                startLAN_button.GetComponent<Button>().onClick.AddListener(() =>
+                {
+                    GameObject.Find("Canvas/MenuContainer/LobbyJoinSettings").gameObject.SetActive(true);
+                });
+            }
+
+            if (GameObject.Find("Canvas/MenuContainer/LobbyJoinSettings") == null)
+            {
+                var menuContainer = GameObject.Find("Canvas/MenuContainer");
+                if (menuContainer == null) return;
+                var LobbyHostSettings = GameObject.Find("Canvas/MenuContainer/LobbyHostSettings");
+                if (LobbyHostSettings == null) return;
+
+                // Clone LobbyHostSettings
+                GameObject menu = GameObject.Instantiate(LobbyHostSettings, LobbyHostSettings.transform.position, LobbyHostSettings.transform.rotation, menuContainer.transform);
+                menu.name = "LobbyJoinSettings";
+
+                var lanSubMenu = menu.transform.Find("HostSettingsContainer");
+                if (lanSubMenu != null)
+                {
+                    lanSubMenu.name = "JoinSettingsContainer";
+                    lanSubMenu.transform.Find("LobbyHostOptions").name = "LobbyJoinOptions";
+
+                    GameObject.Destroy(menu.transform.Find("ChallengeLeaderboard").gameObject);
+                    GameObject.Destroy(menu.transform.Find("FilesPanel").gameObject);
+                    GameObject.Destroy(lanSubMenu.transform.Find("LobbyJoinOptions/OptionsNormal").gameObject);
+                    GameObject.Destroy(lanSubMenu.transform.Find("LobbyJoinOptions/LANOptions/AllowRemote").gameObject);
+                    GameObject.Destroy(lanSubMenu.transform.Find("LobbyJoinOptions/LANOptions/Local").gameObject);
+
+                    var headerText = lanSubMenu.transform.Find("LobbyJoinOptions/LANOptions/Header");
+                    if (headerText != null)
+                        headerText.GetComponent<TextMeshProUGUI>().text = "Join LAN Server:";
+
+                    var addressField = lanSubMenu.transform.Find("LobbyJoinOptions/LANOptions/ServerNameField");
+                    if (addressField != null)
+                    {
+                        addressField.transform.localPosition = new Vector3(0f, 15f, -6.5f);
+                        addressField.gameObject.SetActive(true);
+                    }
+
+                    TMP_InputField ip_field = addressField.GetComponent<TMP_InputField>();
+                    if (ip_field != null)
+                    {
+                        TextMeshProUGUI ip_placeholder = ip_field.placeholder.GetComponent<TextMeshProUGUI>();
+                        ip_placeholder.text = ES3.Load("LANIPAddress", "LCGeneralSaveData", "127.0.0.1");
+
+                        Button confirmBut = lanSubMenu.transform.Find("Confirm")?.GetComponent<Button>();
+                        if (confirmBut != null)
+                        {
+                            confirmBut.onClick = new Button.ButtonClickedEvent();
+                            confirmBut.onClick.AddListener(() =>
+                            {
+                                string IP_Address = "127.0.0.1";
+                                if (ip_field.text != "")
+                                    IP_Address = ip_field.text;
+                                else
+                                    IP_Address = ip_placeholder.text;
+                                ES3.Save("LANIPAddress", IP_Address, "LCGeneralSaveData");
+                                GameObject.Find("Canvas/MenuContainer/LobbyJoinSettings").gameObject.SetActive(false);
+                                LANMenu.JoinLobbyByIP(IP_Address);
+                            });
+                        }
+                    }
+
+                    lanSubMenu.transform.Find("LobbyJoinOptions/LANOptions").gameObject.SetActive(true);
+                }
+            }
         }
     }
 

--- a/MoreCompany/HudPatches.cs
+++ b/MoreCompany/HudPatches.cs
@@ -39,7 +39,8 @@ namespace MoreCompany
     {
         public static void Postfix(MenuManager __instance)
         {
-            MainClass.newPlayerCount = MainClass.playerCount.Value;
+            MainClass.actualPlayerCount = MainClass.playerCount.Value;
+            MainClass.newPlayerCount = Math.Max(4, MainClass.actualPlayerCount);
 
             Transform lobbyHostOptions = __instance.transform.parent.gameObject.transform.Find("MenuContainer/LobbyHostSettings/HostSettingsContainer/LobbyHostOptions");
             if (lobbyHostOptions != null)
@@ -50,7 +51,7 @@ namespace MoreCompany
                     if (parent.Find("CrewCount"))
                     {
                         TMP_InputField inputField = parent.Find("CrewCount").Find("InputField (TMP)").GetComponent<TMP_InputField>();
-                        inputField.text = MainClass.newPlayerCount.ToString();
+                        inputField.text = MainClass.actualPlayerCount.ToString();
                     }
                     else
                     {
@@ -61,7 +62,7 @@ namespace MoreCompany
 
                         TMP_InputField inputField = createdCrewUI.transform.Find("InputField (TMP)").GetComponent<TMP_InputField>();
                         inputField.characterLimit = 3;
-                        inputField.text = MainClass.newPlayerCount.ToString();
+                        inputField.text = MainClass.actualPlayerCount.ToString();
                         inputField.onSubmit.AddListener(s =>
                         {
                             UpdateTextBox(inputField, s);
@@ -77,12 +78,12 @@ namespace MoreCompany
 
         public static void UpdateTextBox(TMP_InputField inputField, string s)
         {
-            if (inputField.text == MainClass.newPlayerCount.ToString())
+            if (inputField.text == MainClass.actualPlayerCount.ToString())
                 return;
 
             if (int.TryParse(s, out int result))
             {
-                int originalCount = MainClass.newPlayerCount;
+                int originalCount = MainClass.actualPlayerCount;
                 MainClass.playerCount.Value = Mathf.Clamp(result, MainClass.minPlayerCount, MainClass.maxPlayerCount);
                 MainClass.StaticConfig.Save();
                 inputField.text = MainClass.playerCount.Value.ToString();
@@ -91,7 +92,7 @@ namespace MoreCompany
             }
             else if (s.Length != 0)
             {
-                inputField.text = MainClass.newPlayerCount.ToString();
+                inputField.text = MainClass.actualPlayerCount.ToString();
                 inputField.caretPosition = 1;
             }
         }

--- a/MoreCompany/HudPatches.cs
+++ b/MoreCompany/HudPatches.cs
@@ -39,15 +39,15 @@ namespace MoreCompany
     {
         public static void Postfix(MenuManager __instance)
         {
-            MainClass.actualPlayerCount = MainClass.playerCount.Value;
-            MainClass.newPlayerCount = Math.Max(4, MainClass.actualPlayerCount);
-
-            Transform lobbyHostOptions = __instance.transform.parent.gameObject.transform.Find("MenuContainer/LobbyHostSettings/HostSettingsContainer/LobbyHostOptions");
+            Transform lobbyHostOptions = __instance.HostSettingsScreen.transform.Find("HostSettingsContainer/LobbyHostOptions");
             if (lobbyHostOptions != null)
             {
                 Transform parent = lobbyHostOptions.Find(GameNetworkManager.Instance.disableSteam ? "LANOptions" : "OptionsNormal");
                 if (parent != null)
                 {
+                    MainClass.actualPlayerCount = __instance.hostSettings_LobbyPublic ? 32 : 12;
+                    MainClass.newPlayerCount = MainClass.actualPlayerCount;
+
                     if (parent.Find("CrewCount"))
                     {
                         TMP_InputField inputField = parent.Find("CrewCount").Find("InputField (TMP)").GetComponent<TMP_InputField>();
@@ -84,11 +84,12 @@ namespace MoreCompany
             if (int.TryParse(s, out int result))
             {
                 int originalCount = MainClass.actualPlayerCount;
-                MainClass.playerCount.Value = Mathf.Clamp(result, MainClass.minPlayerCount, MainClass.maxPlayerCount);
+                MainClass.actualPlayerCount = Mathf.Clamp(result, MainClass.minPlayerCount, MainClass.maxPlayerCount);
+                MainClass.newPlayerCount = Mathf.Max(4, MainClass.actualPlayerCount);
                 MainClass.StaticConfig.Save();
-                inputField.text = MainClass.playerCount.Value.ToString();
-                if (MainClass.playerCount.Value != originalCount)
-                    MainClass.StaticLogger.LogInfo($"Changed Crew Count: {MainClass.playerCount.Value}");
+                inputField.text = MainClass.actualPlayerCount.ToString();
+                if (MainClass.actualPlayerCount != originalCount)
+                    MainClass.StaticLogger.LogInfo($"Changed Crew Count: {MainClass.actualPlayerCount}");
             }
             else if (s.Length != 0)
             {
@@ -266,7 +267,7 @@ namespace MoreCompany
                             SoundManager.Instance.playerVoiceVolumes[finalIndex] = num;
                         }
                     });
-                    playerVolume.value = Math.Clamp((SoundManager.Instance.playerVoiceVolumes[i] * (playerVolume.maxValue - playerVolume.minValue)) + playerVolume.minValue, playerVolume.minValue, playerVolume.maxValue);
+                    playerVolume.value = Mathf.Clamp((SoundManager.Instance.playerVoiceVolumes[i] * (playerVolume.maxValue - playerVolume.minValue)) + playerVolume.minValue, playerVolume.minValue, playerVolume.maxValue);
 
                     Button kickButton = spawnedPlayer.transform.Find("KickButton").GetComponent<Button>();
                     kickButton.onClick.AddListener(() =>

--- a/MoreCompany/LANDiscovery/ClientDiscovery.cs
+++ b/MoreCompany/LANDiscovery/ClientDiscovery.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 
 namespace MoreCompany.LANDiscovery
 {
-    public class Lobby_LAN
+    public class LANLobby
     {
         public string IPAddress;
         public int MemberCount;
@@ -38,10 +38,12 @@ namespace MoreCompany.LANDiscovery
         public int listenPort = 47777;
         internal bool isListening = false;
 
-        private List<Lobby_LAN> discoveredLobbies = new List<Lobby_LAN>();
+        private List<LANLobby> discoveredLobbies = new List<LANLobby>();
 
-        public async Task<List<Lobby_LAN>> DiscoverLobbiesAsync(float discoveryTime)
+        public async Task<List<LANLobby>> DiscoverLobbiesAsync(float discoveryTime)
         {
+            discoveredLobbies.Clear();
+
             udpClient = new UdpClient(listenPort);
             isListening = true;
 
@@ -85,7 +87,7 @@ namespace MoreCompany.LANDiscovery
                     int currentPlayers = int.Parse(parts[2]);
                     int maxPlayers = int.Parse(parts[3]);
 
-                    Lobby_LAN existingLobby = discoveredLobbies.Find(lobby =>
+                    LANLobby existingLobby = discoveredLobbies.Find(lobby =>
                         lobby.IPAddress == ipAddress);
 
                     if (existingLobby != null)
@@ -93,11 +95,11 @@ namespace MoreCompany.LANDiscovery
                         // Overwrite the existing lobby's data
                         existingLobby.MemberCount = currentPlayers;
                         existingLobby.MaxMembers = maxPlayers;
-                        MainClass.StaticLogger.LogInfo($"Updated Lobby: {existingLobby.GetData("name")} at {existingLobby.IPAddress} with {existingLobby.MemberCount}/{existingLobby.MaxMembers} players.");
+                        MainClass.StaticLogger.LogDebug($"Updated Lobby: {existingLobby.GetData("name")} at {existingLobby.IPAddress} with {existingLobby.MemberCount}/{existingLobby.MaxMembers} players.");
                     }
                     else
                     {
-                        Lobby_LAN lobby = new Lobby_LAN
+                        LANLobby lobby = new LANLobby
                         {
                             IPAddress = ipAddress,
                             Data = new Dictionary<string, string>() {

--- a/MoreCompany/LANDiscovery/ClientDiscovery.cs
+++ b/MoreCompany/LANDiscovery/ClientDiscovery.cs
@@ -1,4 +1,3 @@
-using Steamworks.Data;
 using System;
 using System.Collections.Generic;
 using System.Net;

--- a/MoreCompany/LANDiscovery/ClientDiscovery.cs
+++ b/MoreCompany/LANDiscovery/ClientDiscovery.cs
@@ -1,0 +1,125 @@
+using Steamworks.Data;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace MoreCompany.LANDiscovery
+{
+    public class Lobby_LAN
+    {
+        public string IPAddress;
+        public int MemberCount;
+        public int MaxMembers;
+        public Dictionary<string, string> Data;
+        public string GetData(string key)
+        {
+            return Data.ContainsKey(key) ? Data[key] : null;
+        }
+        public void SetData(string key, string value)
+        {
+            if (Data.ContainsKey(key))
+            {
+                Data[key] = value;
+            }
+            else
+            {
+                Data.Add(key, value);
+            }
+        }
+    }
+
+    public class ClientDiscovery : MonoBehaviour
+    {
+        private UdpClient udpClient;
+        public int listenPort = 47777;
+        internal bool isListening = false;
+
+        private List<Lobby_LAN> discoveredLobbies = new List<Lobby_LAN>();
+
+        public async Task<List<Lobby_LAN>> DiscoverLobbiesAsync(float discoveryTime)
+        {
+            udpClient = new UdpClient(listenPort);
+            isListening = true;
+
+            Task listenTask = Task.Run(() => StartListening());
+
+            await Task.Delay(TimeSpan.FromSeconds(discoveryTime));
+
+            isListening = false;
+            udpClient.Close();
+
+            return discoveredLobbies;
+        }
+
+        private void StartListening()
+        {
+            try
+            {
+                while (isListening)
+                {
+                    IPEndPoint ipEndPoint = new IPEndPoint(IPAddress.Any, listenPort);
+                    byte[] data = udpClient.Receive(ref ipEndPoint); // Synchronous receive (non-async here)
+
+                    string message = Encoding.UTF8.GetString(data);
+                    ParseAndStoreLobby(ipEndPoint.Address.ToString(), message);
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError("Error receiving UDP broadcast: " + ex.Message);
+            }
+        }
+
+        private void ParseAndStoreLobby(string ipAddress, string message)
+        {
+            try
+            {
+                string[] parts = message.Split(';');
+                if (parts.Length == 4 && parts[0] == "LC_MC_LAN")
+                {
+                    string lobbyName = parts[1];
+                    int currentPlayers = int.Parse(parts[2]);
+                    int maxPlayers = int.Parse(parts[3]);
+
+                    Lobby_LAN existingLobby = discoveredLobbies.Find(lobby =>
+                        lobby.IPAddress == ipAddress);
+
+                    if (existingLobby != null)
+                    {
+                        // Overwrite the existing lobby's data
+                        existingLobby.MemberCount = currentPlayers;
+                        existingLobby.MaxMembers = maxPlayers;
+                        MainClass.StaticLogger.LogInfo($"Updated Lobby: {existingLobby.GetData("name")} at {existingLobby.IPAddress} with {existingLobby.MemberCount}/{existingLobby.MaxMembers} players.");
+                    }
+                    else
+                    {
+                        Lobby_LAN lobby = new Lobby_LAN
+                        {
+                            IPAddress = ipAddress,
+                            Data = new Dictionary<string, string>() {
+                                { "name", lobbyName }
+                            },
+                            MemberCount = currentPlayers,
+                            MaxMembers = maxPlayers
+                        };
+
+                        discoveredLobbies.Add(lobby);
+                        MainClass.StaticLogger.LogInfo($"Discovered Lobby: {lobby.GetData("name")} at {lobby.IPAddress} with {lobby.MemberCount}/{lobby.MaxMembers} players.");
+                    }
+                }
+                else
+                {
+                    MainClass.StaticLogger.LogWarning("Invalid broadcast format received.");
+                }
+            }
+            catch (Exception ex)
+            {
+                MainClass.StaticLogger.LogError(ex);
+            }
+        }
+    }
+}

--- a/MoreCompany/LANDiscovery/ClientDiscovery.cs
+++ b/MoreCompany/LANDiscovery/ClientDiscovery.cs
@@ -12,6 +12,7 @@ namespace MoreCompany.LANDiscovery
     public class LANLobby
     {
         public string IPAddress;
+        public ushort Port;
         public int MemberCount;
         public int MaxMembers;
         public Dictionary<string, string> Data;
@@ -81,11 +82,12 @@ namespace MoreCompany.LANDiscovery
             try
             {
                 string[] parts = message.Split(';');
-                if (parts.Length == 4 && parts[0] == "LC_MC_LAN")
+                if (parts.Length == 5 && parts[0] == "LC_MC_LAN")
                 {
                     string lobbyName = parts[1];
-                    int currentPlayers = int.Parse(parts[2]);
-                    int maxPlayers = int.Parse(parts[3]);
+                    ushort port = ushort.Parse(parts[2]);
+                    int currentPlayers = int.Parse(parts[3]);
+                    int maxPlayers = int.Parse(parts[4]);
 
                     LANLobby existingLobby = discoveredLobbies.Find(lobby =>
                         lobby.IPAddress == ipAddress);
@@ -95,13 +97,14 @@ namespace MoreCompany.LANDiscovery
                         // Overwrite the existing lobby's data
                         existingLobby.MemberCount = currentPlayers;
                         existingLobby.MaxMembers = maxPlayers;
-                        MainClass.StaticLogger.LogDebug($"Updated Lobby: {existingLobby.GetData("name")} at {existingLobby.IPAddress} with {existingLobby.MemberCount}/{existingLobby.MaxMembers} players.");
+                        MainClass.StaticLogger.LogDebug($"Updated Lobby: {existingLobby.GetData("name")} at {existingLobby.IPAddress}:{existingLobby.Port} with {existingLobby.MemberCount}/{existingLobby.MaxMembers} players.");
                     }
                     else
                     {
                         LANLobby lobby = new LANLobby
                         {
                             IPAddress = ipAddress,
+                            Port = port,
                             Data = new Dictionary<string, string>() {
                                 { "name", lobbyName }
                             },
@@ -110,7 +113,7 @@ namespace MoreCompany.LANDiscovery
                         };
 
                         discoveredLobbies.Add(lobby);
-                        MainClass.StaticLogger.LogInfo($"Discovered Lobby: {lobby.GetData("name")} at {lobby.IPAddress} with {lobby.MemberCount}/{lobby.MaxMembers} players.");
+                        MainClass.StaticLogger.LogInfo($"Discovered Lobby: {lobby.GetData("name")} at {lobby.IPAddress}:{lobby.Port} with {lobby.MemberCount}/{lobby.MaxMembers} players.");
                     }
                 }
                 else

--- a/MoreCompany/LANDiscovery/LANLobbyManager.cs
+++ b/MoreCompany/LANDiscovery/LANLobbyManager.cs
@@ -17,7 +17,7 @@ namespace MoreCompany.LANDiscovery
             "pedophile", "furfag", "necrophilia", "yiff", "sex", "porn"
         };
 
-        internal static Lobby_LAN[] currentLobbyList;
+        internal static LANLobby[] currentLobbyList;
 
         internal static ClientDiscovery clientDiscovery;
 
@@ -70,7 +70,8 @@ namespace MoreCompany.LANDiscovery
                 Object.Destroy(array[i].gameObject);
             }
             GameNetworkManager.Instance.waitingForLobbyDataRefresh = true;
-            Lobby_LAN[] lobbiesArr = (await clientDiscovery.DiscoverLobbiesAsync(2f)).ToArray();
+            clientDiscovery.listenPort = MainClass.lanDiscoveryPort.Value;
+            LANLobby[] lobbiesArr = (await clientDiscovery.DiscoverLobbiesAsync(2f)).ToArray();
             currentLobbyList = lobbiesArr;
             GameNetworkManager.Instance.waitingForLobbyDataRefresh = false;
             if (currentLobbyList != null)
@@ -92,7 +93,7 @@ namespace MoreCompany.LANDiscovery
                 __instance.serverListBlankText.text = "No available servers to join.";
             }
         }
-        private static IEnumerator loadLobbyListAndFilter(Lobby_LAN[] lobbyList, SteamLobbyManager __instance)
+        private static IEnumerator loadLobbyListAndFilter(LANLobby[] lobbyList, SteamLobbyManager __instance)
         {
             for (int i = 0; i < lobbyList.Length; i++)
             {

--- a/MoreCompany/LANDiscovery/LANLobbyManager.cs
+++ b/MoreCompany/LANDiscovery/LANLobbyManager.cs
@@ -91,7 +91,7 @@ namespace MoreCompany.LANDiscovery
             }
             else
             {
-                Debug.Log("Lobby list is null after request.");
+                MainClass.StaticLogger.LogInfo("Lobby list is null after request.");
                 __instance.serverListBlankText.text = "No available servers to join.";
             }
         }
@@ -102,14 +102,14 @@ namespace MoreCompany.LANDiscovery
                 string lobbyName = lobbyList[i].GetData("name");
                 if (lobbyName.Length == 0)
                 {
-                    Debug.Log("lobby name is length of 0, skipping");
+                    MainClass.StaticLogger.LogInfo("lobby name is length of 0, skipping");
                     continue;
                 }
 
                 string lobbyNameNoCapitals = lobbyName.ToLower();
                 if (__instance.censorOffensiveLobbyNames && offensiveWords.Any(x => lobbyNameNoCapitals.Contains(x)))
                 {
-                    Debug.Log("Lobby name is offensive: " + lobbyNameNoCapitals + "; skipping");
+                    MainClass.StaticLogger.LogInfo("Lobby name is offensive: " + lobbyNameNoCapitals + "; skipping");
                     continue;
                 }
 
@@ -134,6 +134,7 @@ namespace MoreCompany.LANDiscovery
                 if (componentInChildren.HostName)
                 {
                     componentInChildren.HostName.GetComponent<TextMeshProUGUI>().text = $"Host: {lobbyList[i].IPAddress}:{lobbyList[i].Port}";
+                    componentInChildren.HostName.transform.localPosition = new Vector3(62f, -18.2f, -4.2f);
                     componentInChildren.HostName.gameObject.SetActive(true);
                 }
 
@@ -142,6 +143,7 @@ namespace MoreCompany.LANDiscovery
                 {
                     JoinButton.onClick = new Button.ButtonClickedEvent();
                     JoinButton.onClick.AddListener(componentInChildren.JoinButton);
+                    LoadLobbyListAndFilterPatch.AddButtonToCopyLobbyCode(JoinButton, $"{lobbyList[i].IPAddress}:{lobbyList[i].Port}");
                 }
 
                 componentInChildren.thisLobby = lobbyList[i];

--- a/MoreCompany/LANDiscovery/LANLobbyManager.cs
+++ b/MoreCompany/LANDiscovery/LANLobbyManager.cs
@@ -1,0 +1,198 @@
+using System.Collections;
+using TMPro;
+using UnityEngine;
+using Object = UnityEngine.Object;
+using HarmonyLib;
+using UnityEngine.UI;
+using System.Linq;
+
+namespace MoreCompany.LANDiscovery
+{
+    [HarmonyPatch]
+    public static class LANLobbyManager
+    {
+        public static string[] offensiveWords = new string[] {
+            "nigger", "faggot", "n1g", "nigers", "cunt", "pussies", "pussy", "minors", "children", "kids",
+            "chink", "buttrape", "molest", "rape", "coon", "negro", "beastiality", "cocks", "cumshot", "ejaculate",
+            "pedophile", "furfag", "necrophilia", "yiff", "sex", "porn"
+        };
+
+        internal static Lobby_LAN[] currentLobbyList;
+
+        internal static ClientDiscovery clientDiscovery;
+
+        [HarmonyPatch(typeof(MenuManager), "Start")]
+        [HarmonyPostfix]
+        public static void MM_Start(MenuManager __instance)
+        {
+            if (GameNetworkManager.Instance.disableSteam)
+            {
+                __instance.lanButtonContainer?.SetActive(false);
+                __instance.joinCrewButtonContainer?.SetActive(true);
+            }
+        }
+
+        [HarmonyPatch(typeof(SteamLobbyManager), "LoadServerList")]
+        [HarmonyPrefix]
+        [HarmonyPriority(Priority.First)]
+        public static bool LoadServerList(SteamLobbyManager __instance)
+        {
+            if (GameNetworkManager.Instance.disableSteam)
+            {
+                GameObject.Find("LobbyList/ListPanel/ToggleChallengeSort")?.SetActive(false); // Hide challenge mode toggle
+                GameObject.Find("LobbyList/ListPanel/Dropdown")?.SetActive(false); // Hide sort dropdown
+                LoadServerList_LAN(__instance);
+                return false;
+            }
+
+            return true;
+        }
+
+        public static async void LoadServerList_LAN(SteamLobbyManager __instance)
+        {
+            if (GameNetworkManager.Instance.waitingForLobbyDataRefresh) return;
+
+            if (!clientDiscovery)
+                clientDiscovery = new ClientDiscovery();
+            if (clientDiscovery.isListening) return;
+
+            if (__instance.loadLobbyListCoroutine != null)
+            {
+                GameNetworkManager.Instance.StopCoroutine(__instance.loadLobbyListCoroutine);
+            }
+
+            __instance.refreshServerListTimer = 0f;
+            __instance.serverListBlankText.text = "Loading server list...";
+            currentLobbyList = null;
+            LANLobbySlot[] array = Object.FindObjectsOfType<LANLobbySlot>();
+            for (int i = 0; i < array.Length; i++)
+            {
+                Object.Destroy(array[i].gameObject);
+            }
+            GameNetworkManager.Instance.waitingForLobbyDataRefresh = true;
+            Lobby_LAN[] lobbiesArr = (await clientDiscovery.DiscoverLobbiesAsync(2f)).ToArray();
+            currentLobbyList = lobbiesArr;
+            GameNetworkManager.Instance.waitingForLobbyDataRefresh = false;
+            if (currentLobbyList != null)
+            {
+                if (currentLobbyList.Length == 0)
+                {
+                    __instance.serverListBlankText.text = "No available servers to join.";
+                }
+                else
+                {
+                    __instance.serverListBlankText.text = "";
+                }
+                __instance.lobbySlotPositionOffset = 0f;
+                __instance.loadLobbyListCoroutine = GameNetworkManager.Instance.StartCoroutine(loadLobbyListAndFilter(currentLobbyList, __instance));
+            }
+            else
+            {
+                Debug.Log("Lobby list is null after request.");
+                __instance.serverListBlankText.text = "No available servers to join.";
+            }
+        }
+        private static IEnumerator loadLobbyListAndFilter(Lobby_LAN[] lobbyList, SteamLobbyManager __instance)
+        {
+            for (int i = 0; i < lobbyList.Length; i++)
+            {
+                string lobbyName = lobbyList[i].GetData("name");
+                if (lobbyName.Length == 0)
+                {
+                    Debug.Log("lobby name is length of 0, skipping");
+                    continue;
+                }
+
+                string lobbyNameNoCapitals = lobbyName.ToLower();
+                if (__instance.censorOffensiveLobbyNames && offensiveWords.Any(x => lobbyNameNoCapitals.Contains(x)))
+                {
+                    Debug.Log("Lobby name is offensive: " + lobbyNameNoCapitals + "; skipping");
+                    continue;
+                }
+
+                GameObject obj = Object.Instantiate(__instance.LobbySlotPrefab, __instance.levelListContainer);
+                obj.GetComponent<RectTransform>().anchoredPosition = new Vector2(0f, 0f + __instance.lobbySlotPositionOffset);
+                __instance.lobbySlotPositionOffset -= 42f;
+                LobbySlot originalSlot = obj.GetComponentInChildren<LobbySlot>();
+
+                // NEW CODE
+                LANLobbySlot componentInChildren = originalSlot.gameObject.AddComponent<LANLobbySlot>();
+                GameObject.Destroy(originalSlot);
+
+                componentInChildren.LobbyName = componentInChildren.transform.Find("ServerName")?.GetComponent<TextMeshProUGUI>();
+                if (componentInChildren.LobbyName)
+                    componentInChildren.LobbyName.text = lobbyName.Substring(0, Mathf.Min(lobbyName.Length, 40));
+
+                componentInChildren.playerCount = componentInChildren.transform.Find("NumPlayers")?.GetComponent<TextMeshProUGUI>();
+                if (componentInChildren.playerCount)
+                    componentInChildren.playerCount.text = $"{lobbyList[i].MemberCount} / {lobbyList[i].MaxMembers}";
+
+                componentInChildren.HostName = componentInChildren.transform.Find("HostName")?.GetComponent<TextMeshProUGUI>();
+                if (componentInChildren.HostName)
+                {
+                    componentInChildren.HostName.GetComponent<TextMeshProUGUI>().text = $"Host: {lobbyList[i].IPAddress}";
+                    componentInChildren.HostName.gameObject.SetActive(true);
+                }
+
+                Button JoinButton = componentInChildren.transform.Find("JoinButton")?.GetComponent<Button>();
+                if (JoinButton)
+                {
+                    JoinButton.onClick = new Button.ButtonClickedEvent();
+                    JoinButton.onClick.AddListener(componentInChildren.JoinButton);
+                }
+
+                componentInChildren.thisLobby = lobbyList[i];
+
+                yield return null;
+            }
+        }
+    }
+
+    [HarmonyPatch]
+    public static class LANHostPatches
+    {
+        [HarmonyPatch(typeof(MenuManager), "Update")]
+        [HarmonyPostfix]
+        public static void MenuManager_Update(MenuManager __instance)
+        {
+            if (GameNetworkManager.Instance == null || !GameNetworkManager.Instance.disableSteam) return;
+            if (!__instance.lobbyTagInputField || !__instance.lobbyTagInputField.gameObject || !__instance.lobbyTagInputField.gameObject.activeSelf) return;
+            __instance.lobbyTagInputField.gameObject.SetActive(false);
+        }
+
+        [HarmonyPatch(typeof(MenuManager), "ClickHostButton")]
+        [HarmonyPrefix]
+        public static void MenuManager_ClickHostButton(MenuManager __instance)
+        {
+            Transform lobbyHostOptions = __instance.HostSettingsScreen.transform.Find("HostSettingsContainer/LobbyHostOptions");
+            if (lobbyHostOptions != null)
+            {
+                if (lobbyHostOptions.transform.Find("LANOptions/AllowRemote") && GameNetworkManager.Instance.disableSteam)
+                {
+                    Object.Destroy(lobbyHostOptions.transform.Find("LANOptions").gameObject);
+                    GameObject OptionsNormal = lobbyHostOptions.transform.Find("OptionsNormal").gameObject;
+                    GameObject menu = GameObject.Instantiate(OptionsNormal, OptionsNormal.transform.position, OptionsNormal.transform.rotation, OptionsNormal.transform.parent);
+                    __instance.HostSettingsOptionsLAN = menu;
+                    __instance.HostSettingsOptionsLAN.name = "LANOptions";
+
+                    Transform accessRemoteBtnParent = __instance.HostSettingsOptionsLAN.transform.Find("Public");
+                    __instance.lanSetAllowRemoteButtonAnimator = accessRemoteBtnParent.GetComponent<Animator>();
+                    Button accessRemoteBtn = accessRemoteBtnParent.GetComponent<Button>();
+                    accessRemoteBtn.onClick = new Button.ButtonClickedEvent();
+                    accessRemoteBtn.onClick.AddListener(__instance.LAN_HostSetAllowRemoteConnections);
+                    accessRemoteBtn.GetComponentInChildren<TextMeshProUGUI>().text = "REMOTE";
+
+                    Transform accessLocalBtnParent = __instance.HostSettingsOptionsLAN.transform.Find("Private");
+                    __instance.lanSetLocalButtonAnimator = accessLocalBtnParent.GetComponent<Animator>();
+                    Button accessLocalBtn = accessLocalBtnParent.GetComponent<Button>();
+                    accessLocalBtn.onClick = new Button.ButtonClickedEvent();
+                    accessLocalBtn.onClick.AddListener(__instance.LAN_HostSetLocal);
+                    accessLocalBtnParent.GetComponentInChildren<TextMeshProUGUI>().text = "LOCAL";
+
+                    __instance.lobbyNameInputField = __instance.HostSettingsOptionsLAN.transform.Find("ServerNameField").GetComponent<TMP_InputField>();
+                    __instance.lobbyTagInputField = __instance.HostSettingsOptionsLAN.transform.Find("ServerTagInputField").GetComponent<TMP_InputField>();
+                }
+            }
+        }
+    }
+}

--- a/MoreCompany/LANDiscovery/LANLobbyManager.cs
+++ b/MoreCompany/LANDiscovery/LANLobbyManager.cs
@@ -11,6 +11,8 @@ namespace MoreCompany.LANDiscovery
     [HarmonyPatch]
     public static class LANLobbyManager
     {
+        public static string DiscoveryKey = "LC_MoreCompany";
+
         public static string[] offensiveWords = new string[] {
             "nigger", "faggot", "n1g", "nigers", "cunt", "pussies", "pussy", "minors", "children", "kids",
             "chink", "buttrape", "molest", "rape", "coon", "negro", "beastiality", "cocks", "cumshot", "ejaculate",
@@ -131,7 +133,7 @@ namespace MoreCompany.LANDiscovery
                 componentInChildren.HostName = componentInChildren.transform.Find("HostName")?.GetComponent<TextMeshProUGUI>();
                 if (componentInChildren.HostName)
                 {
-                    componentInChildren.HostName.GetComponent<TextMeshProUGUI>().text = $"Host: {lobbyList[i].IPAddress}";
+                    componentInChildren.HostName.GetComponent<TextMeshProUGUI>().text = $"Host: {lobbyList[i].IPAddress}:{lobbyList[i].Port}";
                     componentInChildren.HostName.gameObject.SetActive(true);
                 }
 

--- a/MoreCompany/LANDiscovery/LANLobbyManager.cs
+++ b/MoreCompany/LANDiscovery/LANLobbyManager.cs
@@ -143,7 +143,7 @@ namespace MoreCompany.LANDiscovery
                 {
                     JoinButton.onClick = new Button.ButtonClickedEvent();
                     JoinButton.onClick.AddListener(componentInChildren.JoinButton);
-                    LoadLobbyListAndFilterPatch.AddButtonToCopyLobbyCode(JoinButton, $"{lobbyList[i].IPAddress}:{lobbyList[i].Port}");
+                    LoadLobbyListAndFilterPatch.AddButtonToCopyLobbyCode(JoinButton, $"{lobbyList[i].IPAddress}:{lobbyList[i].Port}", ["Copy IP", "Copied", "Invalid"]);
                 }
 
                 componentInChildren.thisLobby = lobbyList[i];

--- a/MoreCompany/LANDiscovery/LANLobbySlot.cs
+++ b/MoreCompany/LANDiscovery/LANLobbySlot.cs
@@ -1,0 +1,23 @@
+using TMPro;
+using Unity.Netcode;
+using Unity.Netcode.Transports.UTP;
+using UnityEngine;
+
+namespace MoreCompany.LANDiscovery
+{
+    public class LANLobbySlot : LobbySlot
+    {
+        public TextMeshProUGUI HostName;
+
+        public new Lobby_LAN thisLobby;
+
+        public new void JoinButton()
+        {
+            MainClass.actualPlayerCount = 4;
+            MainClass.newPlayerCount = MainClass.actualPlayerCount;
+            NetworkManager.Singleton.GetComponent<UnityTransport>().ConnectionData.Address = thisLobby.IPAddress;
+            MainClass.StaticLogger.LogInfo($"Listening to LAN server: {thisLobby.IPAddress}");
+            GameObject.Find("MenuManager").GetComponent<MenuManager>().StartAClient();
+        }
+    }
+}

--- a/MoreCompany/LANDiscovery/LANLobbySlot.cs
+++ b/MoreCompany/LANDiscovery/LANLobbySlot.cs
@@ -13,7 +13,7 @@ namespace MoreCompany.LANDiscovery
 
         public new void JoinButton()
         {
-            LANMenu.JoinLobbyByIP(thisLobby.IPAddress);
+            LANMenu.JoinLobbyByIP(thisLobby.IPAddress, thisLobby.Port);
         }
     }
 }

--- a/MoreCompany/LANDiscovery/LANLobbySlot.cs
+++ b/MoreCompany/LANDiscovery/LANLobbySlot.cs
@@ -1,7 +1,4 @@
 using TMPro;
-using Unity.Netcode;
-using Unity.Netcode.Transports.UTP;
-using UnityEngine;
 
 namespace MoreCompany.LANDiscovery
 {

--- a/MoreCompany/LANDiscovery/LANLobbySlot.cs
+++ b/MoreCompany/LANDiscovery/LANLobbySlot.cs
@@ -9,15 +9,11 @@ namespace MoreCompany.LANDiscovery
     {
         public TextMeshProUGUI HostName;
 
-        public new Lobby_LAN thisLobby;
+        public new LANLobby thisLobby;
 
         public new void JoinButton()
         {
-            MainClass.actualPlayerCount = 4;
-            MainClass.newPlayerCount = MainClass.actualPlayerCount;
-            NetworkManager.Singleton.GetComponent<UnityTransport>().ConnectionData.Address = thisLobby.IPAddress;
-            MainClass.StaticLogger.LogInfo($"Listening to LAN server: {thisLobby.IPAddress}");
-            GameObject.Find("MenuManager").GetComponent<MenuManager>().StartAClient();
+            LANMenu.JoinLobbyByIP(thisLobby.IPAddress);
         }
     }
 }

--- a/MoreCompany/LANDiscovery/ServerDiscovery.cs
+++ b/MoreCompany/LANDiscovery/ServerDiscovery.cs
@@ -21,7 +21,7 @@ namespace MoreCompany.LANDiscovery
                 udpClient = new UdpClient();
                 isServerRunning = true;
                 InvokeRepeating("BroadcastServer", 0, 1.0f); // Broadcast every second
-                MainClass.StaticLogger.LogInfo("[LAN Discovery] Server discovery started");
+                MainClass.StaticLogger.LogInfo("[LAN Discovery] Server discovery broadcasting started");
             }
         }
 
@@ -33,11 +33,11 @@ namespace MoreCompany.LANDiscovery
             IPEndPoint ipEndPoint = new IPEndPoint(IPAddress.Broadcast, MainClass.lanDiscoveryPort.Value);
             List<string> lobbyData = new List<string>()
             {
-                "LC_MC_LAN",
+                LANLobbyManager.DiscoveryKey,
                 NetworkManager.Singleton.GetComponent<UnityTransport>().ConnectionData.Port.ToString(),
-                GameNetworkManager.Instance.lobbyHostSettings.lobbyName.Replace(";", ":"),
                 GameNetworkManager.Instance.connectedPlayers.ToString(),
                 MainClass.actualPlayerCount.ToString(),
+                GameNetworkManager.Instance.lobbyHostSettings.lobbyName.Replace(";", ":"),
             };
 
             byte[] data = Encoding.UTF8.GetBytes(string.Join(';', lobbyData));
@@ -51,7 +51,7 @@ namespace MoreCompany.LANDiscovery
                 isServerRunning = false;
                 CancelInvoke("BroadcastServer");
                 udpClient.Close();
-                MainClass.StaticLogger.LogInfo("[LAN Discovery] Server discovery stopped");
+                MainClass.StaticLogger.LogInfo("[LAN Discovery] Server discovery broadcasting stopped");
             }
         }
 

--- a/MoreCompany/LANDiscovery/ServerDiscovery.cs
+++ b/MoreCompany/LANDiscovery/ServerDiscovery.cs
@@ -4,15 +4,12 @@ using System.Text;
 using UnityEngine;
 using HarmonyLib;
 using System.Collections.Generic;
-using Unity.Netcode.Transports.UTP;
-using Unity.Netcode;
 
 namespace MoreCompany.LANDiscovery
 {
     public class ServerDiscovery : MonoBehaviour
     {
         private UdpClient udpClient;
-        public int broadcastPort = 47777;
         internal bool isServerRunning = false;
 
         public void StartServerDiscovery()
@@ -31,7 +28,7 @@ namespace MoreCompany.LANDiscovery
             if (!isServerRunning)
                 return;
 
-            IPEndPoint ipEndPoint = new IPEndPoint(IPAddress.Broadcast, broadcastPort);
+            IPEndPoint ipEndPoint = new IPEndPoint(IPAddress.Broadcast, MainClass.lanDiscoveryPort.Value);
             List<string> lobbyData = new List<string>()
             {
                 "LC_MC_LAN",

--- a/MoreCompany/LANDiscovery/ServerDiscovery.cs
+++ b/MoreCompany/LANDiscovery/ServerDiscovery.cs
@@ -4,6 +4,8 @@ using System.Text;
 using UnityEngine;
 using HarmonyLib;
 using System.Collections.Generic;
+using Unity.Netcode.Transports.UTP;
+using Unity.Netcode;
 
 namespace MoreCompany.LANDiscovery
 {
@@ -32,7 +34,8 @@ namespace MoreCompany.LANDiscovery
             List<string> lobbyData = new List<string>()
             {
                 "LC_MC_LAN",
-                GameNetworkManager.Instance.lobbyHostSettings.lobbyName,
+                NetworkManager.Singleton.GetComponent<UnityTransport>().ConnectionData.Port.ToString(),
+                GameNetworkManager.Instance.lobbyHostSettings.lobbyName.Replace(";", ":"),
                 GameNetworkManager.Instance.connectedPlayers.ToString(),
                 MainClass.actualPlayerCount.ToString(),
             };

--- a/MoreCompany/LANDiscovery/ServerDiscovery.cs
+++ b/MoreCompany/LANDiscovery/ServerDiscovery.cs
@@ -1,0 +1,97 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using UnityEngine;
+using HarmonyLib;
+using System.Collections.Generic;
+using Unity.Netcode.Transports.UTP;
+using Unity.Netcode;
+
+namespace MoreCompany.LANDiscovery
+{
+    public class ServerDiscovery : MonoBehaviour
+    {
+        private UdpClient udpClient;
+        public int broadcastPort = 47777;
+        internal bool isServerRunning = false;
+
+        public void StartServerDiscovery()
+        {
+            if (!isServerRunning)
+            {
+                udpClient = new UdpClient();
+                isServerRunning = true;
+                InvokeRepeating("BroadcastServer", 0, 1.0f); // Broadcast every second
+                MainClass.StaticLogger.LogInfo("[LAN Discovery] Server discovery started");
+            }
+        }
+
+        void BroadcastServer()
+        {
+            if (!isServerRunning)
+                return;
+
+            IPEndPoint ipEndPoint = new IPEndPoint(IPAddress.Broadcast, broadcastPort);
+            List<string> lobbyData = new List<string>()
+            {
+                "LC_MC_LAN",
+                GameNetworkManager.Instance.lobbyHostSettings.lobbyName,
+                GameNetworkManager.Instance.connectedPlayers.ToString(),
+                MainClass.actualPlayerCount.ToString(),
+            };
+
+            byte[] data = Encoding.UTF8.GetBytes(string.Join(';', lobbyData));
+            udpClient.Send(data, data.Length, ipEndPoint);
+        }
+
+        public void StopServerDiscovery()
+        {
+            if (isServerRunning)
+            {
+                isServerRunning = false;
+                CancelInvoke("BroadcastServer");
+                udpClient.Close();
+                MainClass.StaticLogger.LogInfo("[LAN Discovery] Server discovery stopped");
+            }
+        }
+
+        void OnDestroy()
+        {
+            StopServerDiscovery();
+        }
+    }
+
+    [HarmonyPatch]
+    public static class ServerDiscoveryPatches
+    {
+        public static ServerDiscovery serverDiscovery;
+
+        [HarmonyPatch(typeof(MenuManager), "StartHosting")]
+        [HarmonyPostfix]
+        public static void OnStartServer(MenuManager __instance)
+        {
+            if (__instance.hostSettings_LobbyPublic && GameNetworkManager.Instance.disableSteam)
+            {
+                if (!serverDiscovery)
+                {
+                    GameObject val = new GameObject("ServerDiscovery");
+                    serverDiscovery = val.AddComponent<ServerDiscovery>();
+                    val.hideFlags = (HideFlags)61;
+                    Object.DontDestroyOnLoad(val);
+                }
+
+                serverDiscovery?.StartServerDiscovery();
+            }
+        }
+
+        [HarmonyPatch(typeof(MenuManager), "Awake")]
+        [HarmonyPostfix]
+        public static void OnStopServer()
+        {
+            if (serverDiscovery && serverDiscovery.isServerRunning)
+            {
+                serverDiscovery.StopServerDiscovery();
+            }
+        }
+    }
+}

--- a/MoreCompany/LANMenu.cs
+++ b/MoreCompany/LANMenu.cs
@@ -24,70 +24,70 @@ namespace MoreCompany
                 });
             }
 
-
-            if (GameObject.Find("Canvas/MenuContainer/LobbyJoinSettings") != null) return;
-
-            var menuContainer = GameObject.Find("Canvas/MenuContainer");
-            if (menuContainer == null) return;
-            var LobbyHostSettings = GameObject.Find("Canvas/MenuContainer/LobbyHostSettings");
-            if (LobbyHostSettings == null) return;
-
-            // Clone LobbyHostSettings
-            GameObject menu = Instantiate(LobbyHostSettings, LobbyHostSettings.transform.position, LobbyHostSettings.transform.rotation, menuContainer.transform);
-            menu.name = "LobbyJoinSettings";
-
-            var lanSubMenu = menu.transform.Find("HostSettingsContainer");
-            if (lanSubMenu != null)
+            if (GameObject.Find("Canvas/MenuContainer/LobbyJoinSettings") == null)
             {
-                lanSubMenu.name = "JoinSettingsContainer";
-                lanSubMenu.transform.Find("LobbyHostOptions").name = "LobbyJoinOptions";
+                var menuContainer = GameObject.Find("Canvas/MenuContainer");
+                if (menuContainer == null) return;
+                var LobbyHostSettings = GameObject.Find("Canvas/MenuContainer/LobbyHostSettings");
+                if (LobbyHostSettings == null) return;
 
-                Destroy(menu.transform.Find("ChallengeLeaderboard").gameObject);
-                Destroy(menu.transform.Find("FilesPanel").gameObject);
-                Destroy(lanSubMenu.transform.Find("LobbyJoinOptions/OptionsNormal").gameObject);
-                Destroy(lanSubMenu.transform.Find("LobbyJoinOptions/LANOptions/AllowRemote").gameObject);
-                Destroy(lanSubMenu.transform.Find("LobbyJoinOptions/LANOptions/Local").gameObject);
+                // Clone LobbyHostSettings
+                GameObject menu = Instantiate(LobbyHostSettings, LobbyHostSettings.transform.position, LobbyHostSettings.transform.rotation, menuContainer.transform);
+                menu.name = "LobbyJoinSettings";
 
-                var headerText = lanSubMenu.transform.Find("LobbyJoinOptions/LANOptions/Header");
-                if (headerText != null)
-                    headerText.GetComponent<TextMeshProUGUI>().text = "Join LAN Server:";
-
-                var addressField = lanSubMenu.transform.Find("LobbyJoinOptions/LANOptions/ServerNameField");
-                if (addressField != null)
+                var lanSubMenu = menu.transform.Find("HostSettingsContainer");
+                if (lanSubMenu != null)
                 {
-                    addressField.transform.localPosition = new Vector3(0f, 15f, -6.5f);
-                    addressField.gameObject.SetActive(true);
-                }
+                    lanSubMenu.name = "JoinSettingsContainer";
+                    lanSubMenu.transform.Find("LobbyHostOptions").name = "LobbyJoinOptions";
 
-                TMP_InputField ip_field = addressField.GetComponent<TMP_InputField>();
-                if (ip_field != null)
-                {
-                    TextMeshProUGUI ip_placeholder = ip_field.placeholder.GetComponent<TextMeshProUGUI>();
-                    ip_placeholder.text = ES3.Load("LANIPAddress", "LCGeneralSaveData", "127.0.0.1");
+                    Destroy(menu.transform.Find("ChallengeLeaderboard").gameObject);
+                    Destroy(menu.transform.Find("FilesPanel").gameObject);
+                    Destroy(lanSubMenu.transform.Find("LobbyJoinOptions/OptionsNormal").gameObject);
+                    Destroy(lanSubMenu.transform.Find("LobbyJoinOptions/LANOptions/AllowRemote").gameObject);
+                    Destroy(lanSubMenu.transform.Find("LobbyJoinOptions/LANOptions/Local").gameObject);
 
-                    Button confirmBut = lanSubMenu.transform.Find("Confirm")?.GetComponent<Button>();
-                    if (confirmBut != null)
+                    var headerText = lanSubMenu.transform.Find("LobbyJoinOptions/LANOptions/Header");
+                    if (headerText != null)
+                        headerText.GetComponent<TextMeshProUGUI>().text = "Join LAN Server:";
+
+                    var addressField = lanSubMenu.transform.Find("LobbyJoinOptions/LANOptions/ServerNameField");
+                    if (addressField != null)
                     {
-                        confirmBut.onClick = new Button.ButtonClickedEvent();
-                        confirmBut.onClick.AddListener(() =>
-                        {
-                            string IP_Address = "127.0.0.1";
-                            if (ip_field.text != "")
-                                IP_Address = ip_field.text;
-                            else
-                                IP_Address = ip_placeholder.text;
-                            ES3.Save("LANIPAddress", IP_Address, "LCGeneralSaveData");
-                            GameObject.Find("Canvas/MenuContainer/LobbyJoinSettings").gameObject.SetActive(false);
-                            MainClass.actualPlayerCount = 4;
-                            MainClass.newPlayerCount = MainClass.actualPlayerCount;
-                            NetworkManager.Singleton.GetComponent<UnityTransport>().ConnectionData.Address = IP_Address;
-                            MainClass.StaticLogger.LogInfo($"Listening to LAN server: {IP_Address}");
-                            GameObject.Find("MenuManager").GetComponent<MenuManager>().StartAClient();
-                        });
+                        addressField.transform.localPosition = new Vector3(0f, 15f, -6.5f);
+                        addressField.gameObject.SetActive(true);
                     }
-                }
 
-                lanSubMenu.transform.Find("LobbyJoinOptions/LANOptions").gameObject.SetActive(true);
+                    TMP_InputField ip_field = addressField.GetComponent<TMP_InputField>();
+                    if (ip_field != null)
+                    {
+                        TextMeshProUGUI ip_placeholder = ip_field.placeholder.GetComponent<TextMeshProUGUI>();
+                        ip_placeholder.text = ES3.Load("LANIPAddress", "LCGeneralSaveData", "127.0.0.1");
+
+                        Button confirmBut = lanSubMenu.transform.Find("Confirm")?.GetComponent<Button>();
+                        if (confirmBut != null)
+                        {
+                            confirmBut.onClick = new Button.ButtonClickedEvent();
+                            confirmBut.onClick.AddListener(() =>
+                            {
+                                string IP_Address = "127.0.0.1";
+                                if (ip_field.text != "")
+                                    IP_Address = ip_field.text;
+                                else
+                                    IP_Address = ip_placeholder.text;
+                                ES3.Save("LANIPAddress", IP_Address, "LCGeneralSaveData");
+                                GameObject.Find("Canvas/MenuContainer/LobbyJoinSettings").gameObject.SetActive(false);
+                                MainClass.actualPlayerCount = 4;
+                                MainClass.newPlayerCount = MainClass.actualPlayerCount;
+                                NetworkManager.Singleton.GetComponent<UnityTransport>().ConnectionData.Address = IP_Address;
+                                MainClass.StaticLogger.LogInfo($"Listening to LAN server: {IP_Address}");
+                                GameObject.Find("MenuManager").GetComponent<MenuManager>().StartAClient();
+                            });
+                        }
+                    }
+
+                    lanSubMenu.transform.Find("LobbyJoinOptions/LANOptions").gameObject.SetActive(true);
+                }
             }
         }
     }
@@ -147,7 +147,7 @@ namespace MoreCompany
         private static void LAN_HostSetAllowRemoteConnections(MenuManager __instance)
         {
             __instance.hostSettings_LobbyPublic = true;
-            __instance.privatePublicDescription.text = "PUBLIC means your game will be joinable by anyone on your network.";
+            __instance.privatePublicDescription.text = "REMOTE means your game will be joinable by anyone on your network.";
         }
 
         [HarmonyPatch(typeof(MenuManager), "LAN_HostSetLocal")]
@@ -155,7 +155,7 @@ namespace MoreCompany
         private static void LAN_HostSetLocal(MenuManager __instance)
         {
             __instance.hostSettings_LobbyPublic = false;
-            __instance.privatePublicDescription.text = "PRIVATE means your game will only be joinable from your local machine.";
+            __instance.privatePublicDescription.text = "LOCAL means your game will only be joinable from your local machine.";
         }
 
         [HarmonyPatch(typeof(MenuManager), "HostSetLobbyPublic")]

--- a/MoreCompany/LANMenu.cs
+++ b/MoreCompany/LANMenu.cs
@@ -1,5 +1,4 @@
 using HarmonyLib;
-using System;
 using System.Collections;
 using TMPro;
 using Unity.Netcode;

--- a/MoreCompany/LANMenu.cs
+++ b/MoreCompany/LANMenu.cs
@@ -1,10 +1,12 @@
 using HarmonyLib;
+using System;
 using System.Collections;
 using TMPro;
 using Unity.Netcode;
 using Unity.Netcode.Transports.UTP;
 using UnityEngine;
 using UnityEngine.UI;
+using Object = UnityEngine.Object;
 
 namespace MoreCompany
 {
@@ -77,7 +79,8 @@ namespace MoreCompany
                                 IP_Address = ip_placeholder.text;
                             ES3.Save("LANIPAddress", IP_Address, "LCGeneralSaveData");
                             GameObject.Find("Canvas/MenuContainer/LobbyJoinSettings").gameObject.SetActive(false);
-                            MainClass.newPlayerCount = 4;
+                            MainClass.actualPlayerCount = 4;
+                            MainClass.newPlayerCount = MainClass.actualPlayerCount;
                             NetworkManager.Singleton.GetComponent<UnityTransport>().ConnectionData.Address = IP_Address;
                             MainClass.StaticLogger.LogInfo($"Listening to LAN server: {IP_Address}");
                             GameObject.Find("MenuManager").GetComponent<MenuManager>().StartAClient();
@@ -120,13 +123,14 @@ namespace MoreCompany
         {
             if (__instance.disableSteam && crewSizeMismatch != 0)
             {
-                if (MainClass.newPlayerCount != crewSizeMismatch)
+                if (MainClass.actualPlayerCount != crewSizeMismatch)
                 {
                     GameObject.Find("MenuManager").GetComponent<MenuManager>().menuNotification.SetActive(false);
 
                     // Automatic Reconnect
                     Object.FindObjectOfType<MenuManager>().SetLoadingScreen(isLoading: true);
-                    MainClass.newPlayerCount = crewSizeMismatch;
+                    MainClass.actualPlayerCount = crewSizeMismatch;
+                    MainClass.newPlayerCount = Math.Max(4, MainClass.actualPlayerCount);
                     __instance.StartCoroutine(delayedReconnect());
                 }
 

--- a/MoreCompany/MainClass.cs
+++ b/MoreCompany/MainClass.cs
@@ -79,7 +79,7 @@ namespace MoreCompany
                     playerCount.Value = clampedPlayerCount;
                     StaticConfig.Save();
                 }
-                else
+                else if (StartOfRound.Instance == null)
                 {
                     actualPlayerCount = playerCount.Value;
                     newPlayerCount = Mathf.Max(4, actualPlayerCount);
@@ -91,7 +91,7 @@ namespace MoreCompany
                 playerCount.Value = clampedPlayerCount;
                 StaticConfig.Save();
             }
-            else
+            else if (StartOfRound.Instance == null)
             {
                 actualPlayerCount = playerCount.Value;
                 newPlayerCount = Mathf.Max(4, actualPlayerCount);

--- a/MoreCompany/MainClass.cs
+++ b/MoreCompany/MainClass.cs
@@ -644,7 +644,7 @@ namespace MoreCompany
         {
             if (GameNetworkManager.Instance && GameNetworkManager.Instance.disableSteam)
             {
-                __instance.serverTagInputField.placeholder.gameObject.GetComponent<TextMeshProUGUI>().text = "Enter Server IP";
+                __instance.serverTagInputField.placeholder.gameObject.GetComponent<TextMeshProUGUI>().text = "Enter IP Address";
             }
             else
             {

--- a/MoreCompany/MainClass.cs
+++ b/MoreCompany/MainClass.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Reflection.Emit;
 using System.Text;
 using BepInEx;
+using BepInEx.Bootstrap;
 using BepInEx.Configuration;
 using BepInEx.Logging;
 using GameNetcodeStuff;
@@ -139,6 +140,11 @@ namespace MoreCompany
             LoadAssets(bundle);
 
             StaticLogger.LogInfo("Loaded MoreCompany FULLY");
+
+            if (Chainloader.PluginInfos.ContainsKey("BMX.LobbyCompatibility"))
+            {
+                Compatibility.LobbyCompatibility.Init();
+            }
         }
 
         private void RecursiveCosmeticLoad(string directory)

--- a/MoreCompany/MainClass.cs
+++ b/MoreCompany/MainClass.cs
@@ -105,11 +105,7 @@ namespace MoreCompany
                     CosmeticApplication cosmeticApplication = cosmeticRoot.gameObject.GetComponent<CosmeticApplication>();
                     if (cosmeticApplication == null) continue;
 
-                    foreach (var spawnedCosmetic in cosmeticApplication.spawnedCosmetics)
-                    {
-                        if (spawnedCosmetic.cosmeticType == CosmeticType.HAT && cosmeticApplication.detachedHead) continue;
-                        spawnedCosmetic.gameObject.SetActive(cosmeticsSyncOther.Value);
-                    }
+                    cosmeticApplication.UpdateAllCosmeticVisibilities((int)playerController.playerClientId == StartOfRound.Instance.thisClientPlayerId);
                 }
             };
 
@@ -121,11 +117,7 @@ namespace MoreCompany
                     CosmeticApplication cosmeticApplication = cosmeticRoot.GetComponent<CosmeticApplication>();
                     if (cosmeticApplication == null) continue;
 
-                    foreach (var spawnedCosmetic in cosmeticApplication.spawnedCosmetics)
-                    {
-                        if (spawnedCosmetic.cosmeticType == CosmeticType.HAT && cosmeticApplication.detachedHead) continue;
-                        spawnedCosmetic.gameObject.SetActive(cosmeticsDeadBodies.Value);
-                    }
+                    cosmeticApplication.UpdateAllCosmeticVisibilities(false);
                 }
             };
 
@@ -137,11 +129,8 @@ namespace MoreCompany
                     CosmeticApplication cosmeticApplication = cosmeticRoot.GetComponent<CosmeticApplication>();
                     if (cosmeticApplication == null) continue;
 
-                    foreach (var spawnedCosmetic in cosmeticApplication.spawnedCosmetics)
-                    {
-                        if (spawnedCosmetic.cosmeticType == CosmeticType.HAT && cosmeticApplication.detachedHead) continue;
-                        spawnedCosmetic.gameObject.SetActive(cosmeticsMaskedEnemy.Value);
-                    }
+                    cosmeticApplication.UpdateAllCosmeticVisibilities(false);
+
                     maskedEnemy.skinnedMeshRenderers = maskedEnemy.gameObject.GetComponentsInChildren<SkinnedMeshRenderer>();
                     maskedEnemy.meshRenderers = maskedEnemy.gameObject.GetComponentsInChildren<MeshRenderer>();
                 }

--- a/MoreCompany/MainClass.cs
+++ b/MoreCompany/MainClass.cs
@@ -544,7 +544,7 @@ namespace MoreCompany
     {
         public static void Prefix(ref int maxMembers)
         {
-            maxMembers = MainClass.newPlayerCount;
+            maxMembers = MainClass.actualPlayerCount;
         }
     }
 

--- a/MoreCompany/MoreCompany.csproj
+++ b/MoreCompany/MoreCompany.csproj
@@ -47,13 +47,17 @@
 
   <!-- Runtime dependencies (common) -->
   <ItemGroup>
+    <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="BepInEx.Core" Version="5.4.21" />
     <PackageReference Include="UnityEngine.Modules" Version="2022.3.9" />
   </ItemGroup>
 
   <!-- Runtime dependencies (local) -->
   <ItemGroup Condition="$(CI) != 'true'">
-    <Reference Include="Assembly-CSharp">
+    <Reference Include="Assembly-CSharp" Publicize="true">
       <HintPath>$(LethalCompanyDir)Lethal Company_Data/Managed/Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp-firstpass">

--- a/MoreCompany/MoreCompany.csproj
+++ b/MoreCompany/MoreCompany.csproj
@@ -42,6 +42,7 @@
   <!-- Development dependencies (set 'PrivateAsssets="all"') -->
   <ItemGroup>
     <PackageReference Include="BepInEx.Analyzers" Version="1.0.8" PrivateAssets="all" />
+    <PackageReference Include="TeamBMX.LobbyCompatibility" Version="1.*" PrivateAssets="all" />
   </ItemGroup>
 
   <!-- Runtime dependencies (common) -->
@@ -80,7 +81,7 @@
 
   <!-- Runtime dependencies (CI) -->
   <ItemGroup Condition="$(CI) == 'true'">
-    <PackageReference Include="LethalCompany.GameLibs.Steam" Version="49.0.0-alpha.1" />
+    <PackageReference Include="LethalCompany.GameLibs.Steam" Version="62.0.1-ngd.0" />
   </ItemGroup>
 
   <!-- prevent referenced assemblies from being copied to output folders -->

--- a/MoreCompany/VersionPatches.cs
+++ b/MoreCompany/VersionPatches.cs
@@ -28,8 +28,6 @@ namespace MoreCompany
             if (result != Steamworks.Result.OK)
                 return;
 
-            lobby.SetData("morecompany", "t");
-
             if (lobby.GetData("tag") == "none" && !Chainloader.PluginInfos.ContainsKey("BMX.LobbyCompatibility"))
             {
                 lobby.SetData("tag", "morecompany");
@@ -42,16 +40,21 @@ namespace MoreCompany
     {
         [HarmonyPatch("ApplyFilters")]
         [HarmonyPrefix]
-        public static void ApplyFilters_Prefix(ref LobbyQuery __instance, Dictionary<string, string> ___stringFilters)
+        public static void ApplyFilters_Prefix(Dictionary<string, string> ___stringFilters)
         {
             if (!Chainloader.PluginInfos.ContainsKey("BMX.LobbyCompatibility"))
             {
-                if (!___stringFilters.ContainsKey("morecompany"))
+                bool shouldReplaceTag = false;
+                SteamLobbyManager steamLobbyManager = Object.FindFirstObjectByType<SteamLobbyManager>();
+                if (steamLobbyManager != null)
                 {
-                    ___stringFilters.Add("morecompany", "t");
+                    shouldReplaceTag = steamLobbyManager.serverTagInputField.text == string.Empty;
                 }
-
-                if (!___stringFilters.ContainsKey("tag") || ___stringFilters["tag"] == "none")
+                else if (!___stringFilters.ContainsKey("tag") || ___stringFilters["tag"] == "none")
+                {
+                    shouldReplaceTag = true;
+                }
+                if (shouldReplaceTag)
                 {
                     ___stringFilters.Remove("tag");
                     ___stringFilters.Add("tag", "morecompany");

--- a/MoreCompany/VersionPatches.cs
+++ b/MoreCompany/VersionPatches.cs
@@ -78,11 +78,11 @@ namespace MoreCompany
             foreach (LobbySlot lobbySlot in lobbySlots)
             {
                 lobbySlot.playerCount.text = string.Format("{0} / {1}", lobbySlot.thisLobby.MemberCount, lobbySlot.thisLobby.MaxMembers);
-                AddButtonToCopyLobbyCode(lobbySlot.GetComponentInChildren<Button>(), lobbySlot.lobbyId.Value.ToString());
+                AddButtonToCopyLobbyCode(lobbySlot.GetComponentInChildren<Button>(), lobbySlot.lobbyId.Value.ToString(), ["Code", "Copied", "Invalid"]);
             }
         }
 
-        internal static void AddButtonToCopyLobbyCode(Button LobbyJoinBtn, string lobbyCodeStr)
+        internal static void AddButtonToCopyLobbyCode(Button LobbyJoinBtn, string lobbyCodeStr, string[] textLabels)
         {
             if (LobbyJoinBtn != null)
             {
@@ -91,9 +91,9 @@ namespace MoreCompany
                 RectTransform rectTransform = CopyCodeButton.GetComponent<RectTransform>();
                 rectTransform.anchoredPosition -= new Vector2(78f, 0f);
                 var LobbyCodeTextMesh = CopyCodeButton.GetComponentInChildren<TextMeshProUGUI>();
-                LobbyCodeTextMesh.text = "Code";
+                LobbyCodeTextMesh.text = textLabels[0];
                 CopyCodeButton.onClick = new Button.ButtonClickedEvent();
-                CopyCodeButton.onClick.AddListener(() => CopyLobbyCodeToClipboard(lobbyCodeStr, LobbyCodeTextMesh, ["Code", "Copied", "Invalid"]));
+                CopyCodeButton.onClick.AddListener(() => CopyLobbyCodeToClipboard(lobbyCodeStr, LobbyCodeTextMesh, textLabels));
             }
         }
 

--- a/MoreCompany/VersionPatches.cs
+++ b/MoreCompany/VersionPatches.cs
@@ -1,9 +1,12 @@
+using BepInEx;
 using BepInEx.Bootstrap;
 using HarmonyLib;
 using Steamworks.Data;
 using System.Collections;
 using System.Collections.Generic;
+using TMPro;
 using UnityEngine;
+using UnityEngine.UI;
 
 namespace MoreCompany
 {
@@ -75,7 +78,42 @@ namespace MoreCompany
             foreach (LobbySlot lobbySlot in lobbySlots)
             {
                 lobbySlot.playerCount.text = string.Format("{0} / {1}", lobbySlot.thisLobby.MemberCount, lobbySlot.thisLobby.MaxMembers);
+
+                Button LobbyCodeBtn = lobbySlot.GetComponentInChildren<Button>();
+                if (LobbyCodeBtn != null)
+                {
+                    var CopyCodeButton = Object.Instantiate(LobbyCodeBtn, LobbyCodeBtn.transform.parent);
+                    CopyCodeButton.name = "CopyCodeButton";
+                    RectTransform rectTransform = CopyCodeButton.GetComponent<RectTransform>();
+                    rectTransform.anchoredPosition -= new Vector2(78f, 0f);
+                    var LobbyCodeTextMesh = CopyCodeButton.GetComponentInChildren<TextMeshProUGUI>();
+                    LobbyCodeTextMesh.text = "Code";
+                    CopyCodeButton.onClick = new Button.ButtonClickedEvent();
+                    CopyCodeButton.onClick.AddListener(() => CopyLobbyCodeToClipboard(lobbySlot.lobbyId.Value.ToString(), LobbyCodeTextMesh, ["Code", "Copied", "Invalid"]));
+                }
             }
+        }
+
+        internal static void CopyLobbyCodeToClipboard(string lobbyCode, TextMeshProUGUI textMesh, string[] textLabels)
+        {
+            if (textMesh.text != textLabels[0]) return;
+            GameNetworkManager.Instance.StartCoroutine(LobbySlotCopyCode(lobbyCode, textMesh, textLabels));
+        }
+        internal static IEnumerator LobbySlotCopyCode(string lobbyCode, TextMeshProUGUI textMesh, string[] textLabels)
+        {
+            if (!lobbyCode.IsNullOrWhiteSpace())
+            {
+                GUIUtility.systemCopyBuffer = lobbyCode;
+                MainClass.StaticLogger.LogInfo("Lobby code copied to clipboard: " + lobbyCode);
+                textMesh.text = textLabels[1];
+            }
+            else
+            {
+                textMesh.text = textLabels[2];
+            }
+            yield return new WaitForSeconds(1.2f);
+            textMesh.text = textLabels[0];
+            yield break;
         }
     }
 }

--- a/MoreCompany/VersionPatches.cs
+++ b/MoreCompany/VersionPatches.cs
@@ -1,34 +1,61 @@
+using BepInEx.Bootstrap;
 using HarmonyLib;
+using Steamworks.Data;
 using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace MoreCompany
 {
-    [HarmonyPatch(typeof(GameNetworkManager), "Awake")]
-    public static class GameNetworkAwakePatch
-    {
-        public static int originalVersion = 0;
-
-        public static void Postfix(GameNetworkManager __instance)
-        {
-            originalVersion = __instance.gameVersionNum;
-
-            // LC_API compatibility.
-            if (!BepInEx.Bootstrap.Chainloader.PluginInfos.ContainsKey("LC_API"))
-            {
-	            __instance.gameVersionNum = 9950 + originalVersion;
-            }
-        }
-    }
-
     [HarmonyPatch(typeof(MenuManager), "Awake")]
     public static class MenuManagerVersionDisplayPatch
     {
         public static void Postfix(MenuManager __instance)
         {
-            if (GameNetworkManager.Instance != null && __instance.versionNumberText != null)
+            if (__instance.versionNumberText != null)
             {
-                __instance.versionNumberText.text = string.Format("v{0} (MC)", GameNetworkAwakePatch.originalVersion);
+                __instance.versionNumberText.text = string.Format("{0} (MC)", __instance.versionNumberText.text);
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(GameNetworkManager), "SteamMatchmaking_OnLobbyCreated")]
+    [HarmonyPriority(Priority.Last)]
+    public static class OnLobbyCreatedPatch
+    {
+        private static void Postfix(Steamworks.Result result, ref Lobby lobby)
+        {
+            if (result != Steamworks.Result.OK)
+                return;
+
+            lobby.SetData("morecompany", "t");
+
+            if (lobby.GetData("tag") == "none" && !Chainloader.PluginInfos.ContainsKey("BMX.LobbyCompatibility"))
+            {
+                lobby.SetData("tag", "morecompany");
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(LobbyQuery))]
+    public static class LobbyQueryPatch
+    {
+        [HarmonyPatch("ApplyFilters")]
+        [HarmonyPrefix]
+        public static void ApplyFilters_Prefix(ref LobbyQuery __instance, Dictionary<string, string> ___stringFilters)
+        {
+            if (!Chainloader.PluginInfos.ContainsKey("BMX.LobbyCompatibility"))
+            {
+                if (!___stringFilters.ContainsKey("morecompany"))
+                {
+                    ___stringFilters.Add("morecompany", "t");
+                }
+
+                if (!___stringFilters.ContainsKey("tag") || ___stringFilters["tag"] == "none")
+                {
+                    ___stringFilters.Remove("tag");
+                    ___stringFilters.Add("tag", "morecompany");
+                }
             }
         }
     }

--- a/MoreCompany/VersionPatches.cs
+++ b/MoreCompany/VersionPatches.cs
@@ -78,19 +78,22 @@ namespace MoreCompany
             foreach (LobbySlot lobbySlot in lobbySlots)
             {
                 lobbySlot.playerCount.text = string.Format("{0} / {1}", lobbySlot.thisLobby.MemberCount, lobbySlot.thisLobby.MaxMembers);
+                AddButtonToCopyLobbyCode(lobbySlot.GetComponentInChildren<Button>(), lobbySlot.lobbyId.Value.ToString());
+            }
+        }
 
-                Button LobbyCodeBtn = lobbySlot.GetComponentInChildren<Button>();
-                if (LobbyCodeBtn != null)
-                {
-                    var CopyCodeButton = Object.Instantiate(LobbyCodeBtn, LobbyCodeBtn.transform.parent);
-                    CopyCodeButton.name = "CopyCodeButton";
-                    RectTransform rectTransform = CopyCodeButton.GetComponent<RectTransform>();
-                    rectTransform.anchoredPosition -= new Vector2(78f, 0f);
-                    var LobbyCodeTextMesh = CopyCodeButton.GetComponentInChildren<TextMeshProUGUI>();
-                    LobbyCodeTextMesh.text = "Code";
-                    CopyCodeButton.onClick = new Button.ButtonClickedEvent();
-                    CopyCodeButton.onClick.AddListener(() => CopyLobbyCodeToClipboard(lobbySlot.lobbyId.Value.ToString(), LobbyCodeTextMesh, ["Code", "Copied", "Invalid"]));
-                }
+        internal static void AddButtonToCopyLobbyCode(Button LobbyJoinBtn, string lobbyCodeStr)
+        {
+            if (LobbyJoinBtn != null)
+            {
+                var CopyCodeButton = Object.Instantiate(LobbyJoinBtn, LobbyJoinBtn.transform.parent);
+                CopyCodeButton.name = "CopyCodeButton";
+                RectTransform rectTransform = CopyCodeButton.GetComponent<RectTransform>();
+                rectTransform.anchoredPosition -= new Vector2(78f, 0f);
+                var LobbyCodeTextMesh = CopyCodeButton.GetComponentInChildren<TextMeshProUGUI>();
+                LobbyCodeTextMesh.text = "Code";
+                CopyCodeButton.onClick = new Button.ButtonClickedEvent();
+                CopyCodeButton.onClick.AddListener(() => CopyLobbyCodeToClipboard(lobbyCodeStr, LobbyCodeTextMesh, ["Code", "Copied", "Invalid"]));
             }
         }
 


### PR DESCRIPTION
Requires: https://github.com/notnotnotswipez/MoreCompany/pull/98

- Added a lobby list to LAN
  - You can change the port that the lobby discovery uses in the config
  - Putting an IP address (and optionally a port with a colon between e.g. 127.0.0.1:7777) in the text input at the top will direct connect to that IP address
- Added a config option to change what port is used when hosting a LAN lobby (obviously changing this will result in clients that don't have MoreCompany having no way to join the lobby)
- This also adds LAN support to the [Lobby Codes](https://github.com/notnotnotswipez/MoreCompany/pull/98) PR

If you wanna have a look at the code changes before the required PR is merged then you can look here: https://github.com/1A3Dev/MoreCompany/compare/1a3/lobby-codes...1A3Dev:MoreCompany:1a3/lan-discovery

Video: https://streamable.com/lc8zzx