### PR TITLE
Additional Cosmetic Pin-Points Added & New Unity Package.

### DIFF
--- a/MoreCompany/Cosmetics/CosmeticApplication.cs
+++ b/MoreCompany/Cosmetics/CosmeticApplication.cs
@@ -14,6 +14,16 @@ namespace MoreCompany.Cosmetics
         public Transform shinLeft;
         public Transform shinRight;
         public Transform chest;
+        public Transform upperArmLeft;
+        public Transform upperArmRight;
+        public Transform lowerArmLeft;
+        public Transform handLeft;
+        public Transform handRight;
+        public Transform thighLeft;
+        public Transform thighRight;
+        public Transform footLeft;
+        public Transform footRight;
+
         public List<CosmeticInstance> spawnedCosmetics = new List<CosmeticInstance>();
 
         public void Awake()
@@ -25,6 +35,15 @@ namespace MoreCompany.Cosmetics
             hip = spine;
             shinLeft = spine.Find("thigh.L").Find("shin.L");
             shinRight = spine.Find("thigh.R").Find("shin.R");
+            upperArmLeft = spine.Find("spine.001").Find("spine.002").Find("spine.003").Find("shoulder.L").Find("arm.L_upper");
+            upperArmRight = spine.Find("spine.001").Find("spine.002").Find("spine.003").Find("shoulder.R").Find("arm.R_upper");
+            lowerArmLeft = spine.Find("spine.001").Find("spine.002").Find("spine.003").Find("shoulder.L").Find("arm.L_upper").Find("arm.L_lower");
+            handLeft = spine.Find("spine.001").Find("spine.002").Find("spine.003").Find("shoulder.L").Find("arm.L_upper").Find("arm.L_lower").Find("hand.L");
+            handRight = spine.Find("spine.001").Find("spine.002").Find("spine.003").Find("shoulder.R").Find("arm.R_upper").Find("arm.R_lower").Find("hand.R");
+            thighLeft = spine.Find("thigh.L");
+            thighRight = spine.Find("thigh.R");
+            footLeft = spine.Find("thigh.L").Find("shin.L").Find("foot.L");
+            footRight = spine.Find("thigh.R").Find("shin.R").Find("foot.R");
 
             RefreshAllCosmeticPositions();
         }
@@ -101,6 +120,33 @@ namespace MoreCompany.Cosmetics
                     break;
                 case CosmeticType.CHEST:
                     targetTransform = chest;
+                    break;
+                case CosmeticType.L_UPPER_ARM:
+                    targetTransform = upperArmLeft;
+                    break;
+                case CosmeticType.R_UPPER_ARM:
+                    targetTransform = upperArmRight;
+                    break;
+                case CosmeticType.L_LOWER_ARM:
+                    targetTransform = lowerArmLeft;
+                    break;
+                case CosmeticType.L_HAND:
+                    targetTransform = handLeft;
+                    break;
+                case CosmeticType.R_HAND:
+                    targetTransform = handRight;
+                    break;
+                case CosmeticType.L_THIGH:
+                    targetTransform = thighLeft;
+                    break;
+                case CosmeticType.R_THIGH:
+                    targetTransform = thighRight;
+                    break;
+                case CosmeticType.L_FOOT:
+                    targetTransform = footLeft;
+                    break;
+                case CosmeticType.R_FOOT:
+                    targetTransform = footRight;
                     break;
             }
 

--- a/MoreCompany/Cosmetics/CosmeticApplication.cs
+++ b/MoreCompany/Cosmetics/CosmeticApplication.cs
@@ -17,8 +17,6 @@ namespace MoreCompany.Cosmetics
         public Transform upperArmLeft;
         public Transform upperArmRight;
         public Transform lowerArmLeft;
-        public Transform handLeft;
-        public Transform handRight;
         public Transform thighLeft;
         public Transform thighRight;
         public Transform footLeft;
@@ -38,8 +36,6 @@ namespace MoreCompany.Cosmetics
             upperArmLeft = spine.Find("spine.001").Find("spine.002").Find("spine.003").Find("shoulder.L").Find("arm.L_upper");
             upperArmRight = spine.Find("spine.001").Find("spine.002").Find("spine.003").Find("shoulder.R").Find("arm.R_upper");
             lowerArmLeft = spine.Find("spine.001").Find("spine.002").Find("spine.003").Find("shoulder.L").Find("arm.L_upper").Find("arm.L_lower");
-            handLeft = spine.Find("spine.001").Find("spine.002").Find("spine.003").Find("shoulder.L").Find("arm.L_upper").Find("arm.L_lower").Find("hand.L");
-            handRight = spine.Find("spine.001").Find("spine.002").Find("spine.003").Find("shoulder.R").Find("arm.R_upper").Find("arm.R_lower").Find("hand.R");
             thighLeft = spine.Find("thigh.L");
             thighRight = spine.Find("thigh.R");
             footLeft = spine.Find("thigh.L").Find("shin.L").Find("foot.L");
@@ -129,12 +125,6 @@ namespace MoreCompany.Cosmetics
                     break;
                 case CosmeticType.L_LOWER_ARM:
                     targetTransform = lowerArmLeft;
-                    break;
-                case CosmeticType.L_HAND:
-                    targetTransform = handLeft;
-                    break;
-                case CosmeticType.R_HAND:
-                    targetTransform = handRight;
                     break;
                 case CosmeticType.L_THIGH:
                     targetTransform = thighLeft;

--- a/MoreCompany/Cosmetics/CosmeticInstance.cs
+++ b/MoreCompany/Cosmetics/CosmeticInstance.cs
@@ -44,8 +44,6 @@ namespace MoreCompany.Cosmetics
         L_UPPER_ARM,
         R_UPPER_ARM,
         L_LOWER_ARM,
-        L_HAND,
-        R_HAND,
         L_THIGH,
         R_THIGH,
         L_FOOT,

--- a/MoreCompany/Cosmetics/CosmeticInstance.cs
+++ b/MoreCompany/Cosmetics/CosmeticInstance.cs
@@ -40,6 +40,15 @@ namespace MoreCompany.Cosmetics
         R_LOWER_ARM,
         HIP,
         L_SHIN,
-        R_SHIN
+        R_SHIN,
+        L_UPPER_ARM,
+        R_UPPER_ARM,
+        L_LOWER_ARM,
+        L_HAND,
+        R_HAND,
+        L_THIGH,
+        R_THIGH,
+        L_FOOT,
+        R_FOOT
     }
 }


### PR DESCRIPTION
Additional cosmetic pin-points have been added for additional customizability. New Unity Package has also been attached to be able to take advantage of this change since it has all the old positions and also the new positions I have added available in the prefab. This includes:

* Upper Left Arm
* Upper Right Arm
* Lower Left Arm
* Left Thigh
* Right Thigh
* Left Foot
* Right Foot

I have set this up in a way that does not effect older cosmetics positions or way the bundle is built if it uses an older unity package, as its been added onto the already existing cosmetic system and I have tested ensured it is compatible with other cosmetics that have been built on other versions of More Company. Thigh pin-points have been added because of example being the gun holster cosmetic built into More Company, is tied to the hip, and therefore clips into the leg when emoting or crouching. These pin-points gives a little bit more control over leg cosmetics instead of being tied to the hip and shin, since the shin is connected to the bottom half of the legs instead of the upper part of the legs. With the thigh pin-points, it would resolve the clipping issue if it was bound to the thigh bone instead of the hip.