### PR TITLE
Various Fixes

### DIFF
--- a/MoreCompany/ChatPatches.cs
+++ b/MoreCompany/ChatPatches.cs
@@ -89,7 +89,9 @@ namespace MoreCompany
                 {
                     writer.WriteValueSafe(playerClientId);
                     writer.WriteValueSafe(cosmeticsStr);
-                    NetworkManager.Singleton.CustomMessagingManager.SendNamedMessageToAll("MC_CL_ReceiveCosmetics", writer, NetworkDelivery.Reliable);
+                    NetworkManager.Singleton.CustomMessagingManager.SendNamedMessageToAll("MC_CL_ReceiveCosmetics", writer, writer.Capacity > 1300
+                        ? NetworkDelivery.ReliableFragmentedSequenced
+                        : NetworkDelivery.Reliable);
                 }
 
                 // Sync cosmetics of all clients back to the newly joined client
@@ -101,7 +103,9 @@ namespace MoreCompany
                     using (writerAll)
                     {
                         writerAll.WriteValueSafe(allCosmeticsStr);
-                        NetworkManager.Singleton.CustomMessagingManager.SendNamedMessage("MC_CL_ReceiveAllCosmetics", senderId, writerAll, NetworkDelivery.Reliable);
+                        NetworkManager.Singleton.CustomMessagingManager.SendNamedMessage("MC_CL_ReceiveAllCosmetics", senderId, writerAll, writerAll.Capacity > 1300
+                            ? NetworkDelivery.ReliableFragmentedSequenced
+                            : NetworkDelivery.Reliable);
                     }
                 }
             }
@@ -144,7 +148,9 @@ namespace MoreCompany
                     writer.WriteValueSafe(playerController.playerClientId);
                     writer.WriteValueSafe(cosmeticsStr);
                     writer.WriteValueSafe(requestAll);
-                    NetworkManager.Singleton.CustomMessagingManager.SendNamedMessage("MC_SV_SyncCosmetics", NetworkManager.ServerClientId, writer, NetworkDelivery.Reliable);
+                    NetworkManager.Singleton.CustomMessagingManager.SendNamedMessage("MC_SV_SyncCosmetics", NetworkManager.ServerClientId, writer, writer.Capacity > 1300
+                        ? NetworkDelivery.ReliableFragmentedSequenced
+                        : NetworkDelivery.Reliable);
                 }
                 MainClass.StaticLogger.LogInfo($"Sending {cosmetics.Count} cosmetics to the server | Request All: {requestAll}");
             }

--- a/MoreCompany/ChatPatches.cs
+++ b/MoreCompany/ChatPatches.cs
@@ -135,7 +135,8 @@ namespace MoreCompany
             PlayerControllerB playerController = playerControllerTmp ?? StartOfRound.Instance?.localPlayerController;
             if (playerController != null)
             {
-                string cosmeticsStr = disabled ? "" : string.Join(',', CosmeticRegistry.GetCosmeticsToSync());
+                List<string> cosmetics = CosmeticRegistry.GetCosmeticsToSync();
+                string cosmeticsStr = disabled ? "" : string.Join(',', cosmetics);
                 int writeSize = FastBufferWriter.GetWriteSize(playerController.playerClientId) + FastBufferWriter.GetWriteSize(cosmeticsStr) + FastBufferWriter.GetWriteSize(requestAll);
                 var writer = new FastBufferWriter(writeSize, Allocator.Temp);
                 using (writer)
@@ -145,6 +146,7 @@ namespace MoreCompany
                     writer.WriteValueSafe(requestAll);
                     NetworkManager.Singleton.CustomMessagingManager.SendNamedMessage("MC_SV_SyncCosmetics", NetworkManager.ServerClientId, writer, NetworkDelivery.Reliable);
                 }
+                MainClass.StaticLogger.LogInfo($"Sending {cosmetics.Count} cosmetics to the server | Request All: {requestAll}");
             }
         }
 

--- a/MoreCompany/ChatPatches.cs
+++ b/MoreCompany/ChatPatches.cs
@@ -80,7 +80,7 @@ namespace MoreCompany
 
                 List<string> cosmetics = cosmeticsStr.Split(',').ToList();
                 UpdateCosmeticsForPlayer((int)playerClientId, cosmetics);
-                MainClass.StaticLogger.LogInfo($"Server received {cosmetics.Count} cosmetics from {playerClientId}");
+                MainClass.StaticLogger.LogInfo($"Server received {cosmetics.Count} cosmetics from {playerClientId} | Request All: {requestAll}");
 
                 // Sync the sender's cosmetics to all clients
                 int writeSize = FastBufferWriter.GetWriteSize(playerClientId) + FastBufferWriter.GetWriteSize(cosmeticsStr);

--- a/MoreCompany/ChatPatches.cs
+++ b/MoreCompany/ChatPatches.cs
@@ -30,7 +30,7 @@ namespace MoreCompany
     public static class CosmeticSyncPatch
     {
         // This method runs whenever a player's cosmetics are updated
-        public static void UpdateCosmeticsForPlayer(int playerClientId, List<string> splitMessage, bool showOwnCosmetics = false)
+        public static void UpdateCosmeticsForPlayer(int playerClientId, List<string> splitMessage)
         {
             CosmeticApplication cosmeticApplication = StartOfRound.Instance.allPlayerScripts[playerClientId].transform.Find("ScavengerModel")
                 .Find("metarig").gameObject.GetComponent<CosmeticApplication>();
@@ -41,24 +41,24 @@ namespace MoreCompany
                 .Find("metarig").gameObject.AddComponent<CosmeticApplication>();
             }
 
-            cosmeticApplication.ClearCosmetics();
+            cosmeticApplication.parentType = ParentType.Player;
 
+            cosmeticApplication.ClearCosmetics();
             List<string> cosmeticsToApply = new List<string>();
             foreach (string cosmeticId in splitMessage)
             {
-                cosmeticsToApply.Add(cosmeticId);
-                cosmeticApplication.ApplyCosmetic(cosmeticId, MainClass.cosmeticsSyncOther.Value);
-            }
-
-            if (playerClientId == StartOfRound.Instance.thisClientPlayerId && !showOwnCosmetics)
-            {
-                cosmeticApplication.ClearCosmetics();
+                if (cosmeticApplication.ApplyCosmetic(cosmeticId, false))
+                {
+                    cosmeticsToApply.Add(cosmeticId);
+                }
             }
 
             foreach (var cosmeticSpawned in cosmeticApplication.spawnedCosmetics)
             {
                 cosmeticSpawned.transform.localScale *= CosmeticRegistry.COSMETIC_PLAYER_SCALE_MULT;
             }
+
+            cosmeticApplication.UpdateAllCosmeticVisibilities(playerClientId == StartOfRound.Instance.thisClientPlayerId);
 
             if (MainClass.playerIdsAndCosmetics.ContainsKey(playerClientId))
             {

--- a/MoreCompany/CosmeticPatches.cs
+++ b/MoreCompany/CosmeticPatches.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using GameNetcodeStuff;
 using HarmonyLib;
 using MoreCompany.Cosmetics;
@@ -10,29 +9,33 @@ namespace MoreCompany
     [HarmonyPatch]
     public class CosmeticPatches
     {
-        public static bool CloneCosmeticsToNonPlayer(Transform cosmeticRoot, int playerClientId, bool detachedHead = false, bool startEnabled = true)
+        public static bool CloneCosmeticsToNonPlayer(ParentType parentType, Transform cosmeticRoot, int playerClientId, bool detachedHead = false)
         {
             if (MainClass.playerIdsAndCosmetics.ContainsKey(playerClientId))
             {
                 List<string> cosmetics = MainClass.playerIdsAndCosmetics[playerClientId];
                 CosmeticApplication cosmeticApplication = cosmeticRoot.GetComponent<CosmeticApplication>();
-                if (cosmeticApplication)
+
+                if (!cosmeticApplication)
                 {
-                    cosmeticApplication.ClearCosmetics();
-                    GameObject.Destroy(cosmeticApplication);
+                    cosmeticApplication = cosmeticRoot.gameObject.AddComponent<CosmeticApplication>();
                 }
 
-                cosmeticApplication = cosmeticRoot.gameObject.AddComponent<CosmeticApplication>();
+                cosmeticApplication.parentType = parentType;
                 cosmeticApplication.detachedHead = detachedHead;
-                foreach (var cosmetic in cosmetics)
+
+                cosmeticApplication.ClearCosmetics();
+                foreach (var cosmeticId in cosmetics)
                 {
-                    cosmeticApplication.ApplyCosmetic(cosmetic, startEnabled);
+                    cosmeticApplication.ApplyCosmetic(cosmeticId, false);
                 }
 
                 foreach (var cosmetic in cosmeticApplication.spawnedCosmetics)
                 {
                     cosmetic.transform.localScale *= CosmeticRegistry.COSMETIC_PLAYER_SCALE_MULT;
                 }
+
+                cosmeticApplication.UpdateAllCosmeticVisibilities(false);
 
                 return true;
             }
@@ -48,7 +51,7 @@ namespace MoreCompany
             if (cosmeticRoot == null) return;
             bool detachedHead = __instance.deadBody.detachedHead;
             if (deathAnimation == 4 || deathAnimation == 5) detachedHead = true; // Masked
-            CloneCosmeticsToNonPlayer(cosmeticRoot, (int)__instance.playerClientId, detachedHead: detachedHead, startEnabled: MainClass.cosmeticsDeadBodies.Value);
+            CloneCosmeticsToNonPlayer(ParentType.DeadBody, cosmeticRoot, (int)__instance.playerClientId, detachedHead: detachedHead);
         }
 
         // "Why this function? Why not Start/Awake/Another function?" Well, Start and Awake are called on clients that arent the host before the mimicking player is set.
@@ -60,7 +63,7 @@ namespace MoreCompany
             if (__instance.mimickingPlayer == null) return;
             Transform cosmeticRoot = __instance.transform.Find("ScavengerModel").Find("metarig");
             if (cosmeticRoot == null) return;
-            CloneCosmeticsToNonPlayer(cosmeticRoot, (int)__instance.mimickingPlayer.playerClientId, detachedHead: false, startEnabled: MainClass.cosmeticsMaskedEnemy.Value);
+            CloneCosmeticsToNonPlayer(ParentType.MaskedEnemy, cosmeticRoot, (int)__instance.mimickingPlayer.playerClientId, detachedHead: false);
             __instance.skinnedMeshRenderers = __instance.gameObject.GetComponentsInChildren<SkinnedMeshRenderer>();
             __instance.meshRenderers = __instance.gameObject.GetComponentsInChildren<MeshRenderer>();
         }

--- a/MoreCompany/Cosmetics/CosmeticApplication.cs
+++ b/MoreCompany/Cosmetics/CosmeticApplication.cs
@@ -10,6 +10,7 @@ namespace MoreCompany.Cosmetics
         Player,
         DeadBody,
         MaskedEnemy,
+        DisplayGuy,
     }
 
     public class CosmeticApplication : MonoBehaviour
@@ -30,12 +31,15 @@ namespace MoreCompany.Cosmetics
         public void Awake()
         {
             Transform spine = transform.Find("spine") ?? transform;
-            head = spine.Find("spine.001").Find("spine.002").Find("spine.003").Find("spine.004");
             chest = spine.Find("spine.001").Find("spine.002").Find("spine.003");
-            lowerArmRight = spine.Find("spine.001").Find("spine.002").Find("spine.003").Find("shoulder.R").Find("arm.R_upper").Find("arm.R_lower");
+            head = chest.Find("spine.004");
+            lowerArmRight = chest.Find("shoulder.R").Find("arm.R_upper").Find("arm.R_lower");
             hip = spine;
             shinLeft = spine.Find("thigh.L").Find("shin.L");
             shinRight = spine.Find("thigh.R").Find("shin.R");
+
+            if (parentType == ParentType.DisplayGuy)
+                CosmeticRegistry.UpdateCosmeticsOnDisplayGuy(false);
 
             RefreshAllCosmeticPositions();
         }
@@ -119,6 +123,10 @@ namespace MoreCompany.Cosmetics
             else if (parentType == ParentType.MaskedEnemy)
             {
                 isActive = MainClass.cosmeticsMaskedEnemy.Value;
+            }
+            else if (parentType == ParentType.DisplayGuy)
+            {
+                isActive = true;
             }
 
             foreach (var spawnedCosmetic in spawnedCosmetics)

--- a/MoreCompany/Cosmetics/CosmeticApplication.cs
+++ b/MoreCompany/Cosmetics/CosmeticApplication.cs
@@ -1,12 +1,22 @@
+using GameNetcodeStuff;
 using System;
 using System.Collections.Generic;
 using UnityEngine;
 
 namespace MoreCompany.Cosmetics
 {
+    public enum ParentType
+    {
+        Player,
+        DeadBody,
+        MaskedEnemy,
+    }
+
     public class CosmeticApplication : MonoBehaviour
     {
         public bool detachedHead = false;
+
+        public ParentType parentType;
 
         public Transform head;
         public Transform hip;
@@ -15,6 +25,7 @@ namespace MoreCompany.Cosmetics
         public Transform shinRight;
         public Transform chest;
         public List<CosmeticInstance> spawnedCosmetics = new List<CosmeticInstance>();
+        public List<string> spawnedCosmeticsIds = new List<string>();
 
         public void Awake()
         {
@@ -39,10 +50,28 @@ namespace MoreCompany.Cosmetics
 
         private void OnEnable()
         {
-            foreach (var spawnedCosmetic in spawnedCosmetics)
+            if (spawnedCosmetics.Count > 0)
             {
-                if (spawnedCosmetic.cosmeticType == CosmeticType.HAT && detachedHead) continue;
-                spawnedCosmetic.gameObject.SetActive(true);
+                if (parentType == ParentType.Player)
+                {
+                    PlayerControllerB playerController = transform.GetComponentInParent<PlayerControllerB>();
+                    UpdateAllCosmeticVisibilities(playerController != null && (int)playerController.playerClientId == StartOfRound.Instance.thisClientPlayerId);
+                }
+                else if (parentType == ParentType.MaskedEnemy)
+                {
+                    UpdateAllCosmeticVisibilities();
+
+                    MaskedPlayerEnemy maskedEnemy = transform.GetComponentInParent<MaskedPlayerEnemy>();
+                    if (maskedEnemy != null)
+                    {
+                        maskedEnemy.skinnedMeshRenderers = maskedEnemy.gameObject.GetComponentsInChildren<SkinnedMeshRenderer>();
+                        maskedEnemy.meshRenderers = maskedEnemy.gameObject.GetComponentsInChildren<MeshRenderer>();
+                    }
+                }
+                else
+                {
+                    UpdateAllCosmeticVisibilities();
+                }
             }
         }
 
@@ -53,24 +82,52 @@ namespace MoreCompany.Cosmetics
                 GameObject.Destroy(spawnedCosmetic.gameObject);
             }
             spawnedCosmetics.Clear();
+            spawnedCosmeticsIds.Clear();
         }
-        
-        public void ApplyCosmetic(string cosmeticId, bool startEnabled)
+
+        public bool ApplyCosmetic(string cosmeticId, bool startEnabled)
         {
-            if (CosmeticRegistry.cosmeticInstances.ContainsKey(cosmeticId))
+            if (CosmeticRegistry.cosmeticInstances.ContainsKey(cosmeticId) && !spawnedCosmeticsIds.Contains(cosmeticId))
             {
                 CosmeticInstance cosmeticInstance = CosmeticRegistry.cosmeticInstances[cosmeticId];
 
-                if (startEnabled && cosmeticInstance.cosmeticType == CosmeticType.HAT && detachedHead) return;
+                if (startEnabled && cosmeticInstance.cosmeticType == CosmeticType.HAT && detachedHead) return false;
 
                 GameObject cosmeticInstanceGameObject = GameObject.Instantiate(cosmeticInstance.gameObject);
                 cosmeticInstanceGameObject.SetActive(startEnabled);
                 CosmeticInstance cosmeticInstanceBehavior = cosmeticInstanceGameObject.GetComponent<CosmeticInstance>();
                 spawnedCosmetics.Add(cosmeticInstanceBehavior);
                 ParentCosmetic(cosmeticInstanceBehavior);
+                spawnedCosmeticsIds.Add(cosmeticId);
+                return true;
+            }
+
+            return false;
+        }
+
+        public void UpdateAllCosmeticVisibilities(bool isLocalPlayer = false)
+        {
+            bool isActive = false;
+            if (parentType == ParentType.Player)
+            {
+                isActive = MainClass.cosmeticsSyncOther.Value && !isLocalPlayer;
+            }
+            else if (parentType == ParentType.DeadBody)
+            {
+                isActive = MainClass.cosmeticsDeadBodies.Value;
+            }
+            else if (parentType == ParentType.MaskedEnemy)
+            {
+                isActive = MainClass.cosmeticsMaskedEnemy.Value;
+            }
+
+            foreach (var spawnedCosmetic in spawnedCosmetics)
+            {
+                if (spawnedCosmetic.cosmeticType == CosmeticType.HAT && detachedHead) continue;
+                spawnedCosmetic.gameObject.SetActive(isActive);
             }
         }
-        
+
         public void RefreshAllCosmeticPositions()
         {
             foreach (var spawnedCosmetic in spawnedCosmetics)
@@ -79,7 +136,7 @@ namespace MoreCompany.Cosmetics
             }
         }
 
-        private void ParentCosmetic(CosmeticInstance cosmeticInstance)
+        private bool ParentCosmetic(CosmeticInstance cosmeticInstance)
         {
             Transform targetTransform = null;
             switch (cosmeticInstance.cosmeticType)
@@ -107,12 +164,13 @@ namespace MoreCompany.Cosmetics
             if (targetTransform == null)
             {
                 MainClass.StaticLogger.LogError("Failed to find transform of type: " + cosmeticInstance.cosmeticType);
-                return;
+                return false;
             }
 
             cosmeticInstance.transform.position = targetTransform.position;
             cosmeticInstance.transform.rotation = targetTransform.rotation;
             cosmeticInstance.transform.parent = targetTransform;
+            return true;
         }
     }
 }

--- a/MoreCompany/Cosmetics/CosmeticRegistry.cs
+++ b/MoreCompany/Cosmetics/CosmeticRegistry.cs
@@ -105,6 +105,7 @@ namespace MoreCompany.Cosmetics
                 .Find("ScavengerModel").Find("metarig").gameObject;
 
             displayGuyCosmeticApplication = displayGuy.AddComponent<CosmeticApplication>();
+            displayGuyCosmeticApplication.parentType = ParentType.DisplayGuy;
 
             GameObject enableCosmeticsButton = cosmeticGUIGlobalScale.Find("CosmeticsScreen").Find("EnableButton").gameObject;
             GameObject disableCosmeticsButton = cosmeticGUIGlobalScale.Find("CosmeticsScreen").Find("DisableButton").gameObject;
@@ -122,7 +123,6 @@ namespace MoreCompany.Cosmetics
             UpdateVisibilityCheckbox(enableCosmeticsButton, disableCosmeticsButton);
 
             PopulateCosmetics();
-            UpdateCosmeticsOnDisplayGuy(false);
         }
 
         public static void PopulateCosmetics()

--- a/MoreCompany/Cosmetics/CosmeticRegistry.cs
+++ b/MoreCompany/Cosmetics/CosmeticRegistry.cs
@@ -211,7 +211,7 @@ namespace MoreCompany.Cosmetics
             }
         }
 
-        private static void RecursiveLayerChange(Transform transform, int layer)
+        public static void RecursiveLayerChange(Transform transform, int layer)
         {
             transform.gameObject.layer = layer;
             for (int i = 0; i < transform.childCount; i++)

--- a/MoreCompany/LANMenu.cs
+++ b/MoreCompany/LANMenu.cs
@@ -22,10 +22,6 @@ namespace MoreCompany
                 startLAN_button.GetComponent<Button>().onClick = new Button.ButtonClickedEvent();
                 startLAN_button.GetComponent<Button>().onClick.AddListener(() =>
                 {
-                    TextMeshProUGUI footerText = GameObject.Find("Canvas/MenuContainer/LobbyJoinSettings/JoinSettingsContainer/PrivatePublicDescription").GetComponent<TextMeshProUGUI>();
-                    if (footerText != null)
-                        footerText.text = "The mod will attempt to auto-detect the crew size however you can manually specify it to reduce chance of failure.";
-
                     GameObject.Find("Canvas/MenuContainer/LobbyJoinSettings").gameObject.SetActive(true);
                 });
             }
@@ -91,10 +87,6 @@ namespace MoreCompany
                         });
                     }
                 }
-
-                TextMeshProUGUI footerText = lanSubMenu.transform.Find("PrivatePublicDescription").GetComponent<TextMeshProUGUI>();
-                if (footerText != null)
-                    footerText.text = "The mod will attempt to auto-detect the crew size however you can manually specify it to reduce chance of failure.";
 
                 lanSubMenu.transform.Find("LobbyJoinOptions/LANOptions").gameObject.SetActive(true);
             }

--- a/MoreCompany/LANMenu.cs
+++ b/MoreCompany/LANMenu.cs
@@ -103,19 +103,6 @@ namespace MoreCompany
         }
     }
 
-    // Crew Size Mismatch
-    [HarmonyPatch(typeof(GameNetworkManager), "SetConnectionDataBeforeConnecting")]
-    public static class ConnectionDataPatch
-    {
-        public static void Postfix(ref GameNetworkManager __instance)
-        {
-            if (__instance.disableSteam)
-            {
-                NetworkManager.Singleton.NetworkConfig.ConnectionData = Encoding.ASCII.GetBytes(__instance.gameVersionNum.ToString() + "," + MainClass.newPlayerCount);
-            }
-        }
-    }
-
     [HarmonyPatch(typeof(GameNetworkManager), "OnLocalClientConnectionDisapproved")]
     public static class ConnectionDisapprovedPatch
     {
@@ -127,7 +114,7 @@ namespace MoreCompany
             yield break;
         }
 
-        private static void Prefix(ref GameNetworkManager __instance, ulong clientId)
+        private static void Prefix(GameNetworkManager __instance, ulong clientId)
         {
             crewSizeMismatch = 0;
             if (__instance.disableSteam)
@@ -142,7 +129,7 @@ namespace MoreCompany
                 catch { }
             }
         }
-        private static void Postfix(ref GameNetworkManager __instance, ulong clientId)
+        private static void Postfix(GameNetworkManager __instance, ulong clientId)
         {
             if (__instance.disableSteam && crewSizeMismatch != 0)
             {


### PR DESCRIPTION
Taken from https://github.com/notnotnotswipez/MoreCompany/pull/96 due to that PR requiring some additional changes for the lobby filtering stuff

- Cosmetic Changes
  - Fixed the same cosmetic being able to spawn multiple times if you somehow have it in the list of enabled cosmetics multiple times
  - Made cosmetics on the local player be hidden instead of cleared
  - Added a method that is used to update the visibility of all cosmetics (so other mods can patch it if they need to)
  - Fixed the display guy causing the "Failed to find transform of type" error (since it starts inactive the Awake didn't run before setting the transforms)
  - Fixed cosmetics not syncing to newly joined players if the data is too large
- Improved compatibility for other mods appending data to the initial connection data (`NetworkManager.Singleton.NetworkConfig.ConnectionData`)
- Improved compatibility for other mods that have a custom input for the max player count