### PR TITLE
Small Changes

### DIFF
--- a/MoreCompany/Cosmetics/CosmeticApplication.cs
+++ b/MoreCompany/Cosmetics/CosmeticApplication.cs
@@ -48,7 +48,7 @@ namespace MoreCompany.Cosmetics
         {
             foreach (var spawnedCosmetic in spawnedCosmetics)
             {
-                spawnedCosmetic.gameObject.SetActive(false);
+                spawnedCosmetic?.gameObject.SetActive(false);
             }
         }
 
@@ -83,7 +83,7 @@ namespace MoreCompany.Cosmetics
         {
             foreach (var spawnedCosmetic in spawnedCosmetics)
             {
-                GameObject.Destroy(spawnedCosmetic.gameObject);
+                GameObject.Destroy(spawnedCosmetic?.gameObject);
             }
             spawnedCosmetics.Clear();
             spawnedCosmeticsIds.Clear();
@@ -131,7 +131,7 @@ namespace MoreCompany.Cosmetics
 
             foreach (var spawnedCosmetic in spawnedCosmetics)
             {
-                if (spawnedCosmetic.cosmeticType == CosmeticType.HAT && detachedHead) continue;
+                if (!spawnedCosmetic || (spawnedCosmetic.cosmeticType == CosmeticType.HAT && detachedHead)) continue;
                 spawnedCosmetic.gameObject.SetActive(isActive);
             }
         }
@@ -140,6 +140,7 @@ namespace MoreCompany.Cosmetics
         {
             foreach (var spawnedCosmetic in spawnedCosmetics)
             {
+                if(!spawnedCosmetic) continue;
                 ParentCosmetic(spawnedCosmetic);
             }
         }

--- a/MoreCompany/MoreCompany.csproj
+++ b/MoreCompany/MoreCompany.csproj
@@ -80,7 +80,7 @@
 
   <!-- Runtime dependencies (CI) -->
   <ItemGroup Condition="$(CI) == 'true'">
-    <PackageReference Include="LethalCompany.GameLibs.Steam" Version="49.0.0-alpha.1" />
+    <PackageReference Include="LethalCompany.GameLibs.Steam" Version="*-*" />
   </ItemGroup>
 
   <!-- prevent referenced assemblies from being copied to output folders -->

--- a/MoreCompany/VersionPatches.cs
+++ b/MoreCompany/VersionPatches.cs
@@ -26,9 +26,9 @@ namespace MoreCompany
     {
         public static void Postfix(MenuManager __instance)
         {
-            if (GameNetworkManager.Instance != null && __instance.versionNumberText != null)
+            if (!__instance.isInitScene && __instance.versionNumberText != null)
             {
-                __instance.versionNumberText.text = string.Format("v{0} (MC)", GameNetworkAwakePatch.originalVersion);
+                __instance.versionNumberText.text = string.Format("{0} (MC)", __instance.versionNumberText.text.Replace($"v{9950 + GameNetworkAwakePatch.originalVersion}", $"v{GameNetworkAwakePatch.originalVersion}"));
             }
         }
     }


### PR DESCRIPTION
- Made the version number text on the main menu be appended to the end of the existing text rather than overwriting it
- Fixed possible exception if a `spawnedCosmetic` is somehow `null`
- Made gamelibs always use the latest game version