### PR TITLE
Fixed NullReferenceException if a chat message is null

### DIFF
--- a/MoreCompany/ChatPatches.cs
+++ b/MoreCompany/ChatPatches.cs
@@ -15,7 +15,7 @@ namespace MoreCompany
     {
         public static bool Prefix(string chatMessage, int playerId = -1)
         {
-            if (DebugCommandRegistry.commandEnabled && StartOfRound.Instance.IsHost && chatMessage.StartsWith("/mc"))
+            if (DebugCommandRegistry.commandEnabled && StartOfRound.Instance.IsHost && chatMessage != null && chatMessage.StartsWith("/mc"))
             {
                 String command = chatMessage.Replace("/mc ", "");
                 DebugCommandRegistry.HandleCommand(command.Split(' '));
@@ -196,7 +196,7 @@ namespace MoreCompany
         [HarmonyPrefix]
         public static bool AddChatMessage_Prefix(string chatMessage, string nameOfUserWhoTyped = "")
         {
-            if (chatMessage.StartsWith("[replacewithdata]") || chatMessage.StartsWith("[morecompanycosmetics]"))
+            if (chatMessage != null && (chatMessage.StartsWith("[replacewithdata]") || chatMessage.StartsWith("[morecompanycosmetics]")))
             {
                 return false;
             }


### PR DESCRIPTION
- Fixed NullReferenceException if a chat message is null

```NullReferenceException: Object reference not set to an instance of an object
Stack trace:
MoreCompany.PreventOldVersionChatSpamPatch.AddChatMessage_Prefix (System.String chatMessage, System.String nameOfUserWhoTyped) (at D:/VisualStudioProjects/MoreCompany/MoreCompany/ChatPatches.cs:199)
(wrapper dynamic-method) HUDManager.DMD<HUDManager::AddChatMessage>(HUDManager,string,string,int,bool)
HUDManager.AddTextMessageClientRpc (System.String chatMessage) (at <bc42cf6950c34b22862bb697b6cfe961>:IL_010```