### PR TITLE
Made modded toggle be enabled by default on the server list

### DIFF
--- a/MoreCompany/HudPatches.cs
+++ b/MoreCompany/HudPatches.cs
@@ -417,6 +417,7 @@ namespace MoreCompany
     {
         public static void Postfix(SteamLobbyManager __instance)
         {
+            __instance.sortWithModdedClientsCheckbox.transform.parent.gameObject.SetActive(false);
             bool sortWithModdedClients = ReflectionUtils.GetFieldValue<bool>(__instance, "sortWithModdedClients");
             if (!sortWithModdedClients)
             {

--- a/MoreCompany/HudPatches.cs
+++ b/MoreCompany/HudPatches.cs
@@ -411,4 +411,17 @@ namespace MoreCompany
             uiElements.playerStates[index] = playerState.GetComponent<Image>();
         }
     }
+
+    [HarmonyPatch(typeof(SteamLobbyManager), "OnEnable")]
+    public static class SteamLobbyManagerPatch
+    {
+        public static void Postfix(SteamLobbyManager __instance)
+        {
+            bool sortWithModdedClients = ReflectionUtils.GetFieldValue<bool>(__instance, "sortWithModdedClients");
+            if (!sortWithModdedClients)
+            {
+                __instance.ToggleSortWithModdedClients();
+            }
+        }
+    }
 }


### PR DESCRIPTION
- Made the modded filter on the server list be enabled by default so you don't have to manually toggle it each time you open the server list (since you can't see MoreCompany lobbies unless it's enabled).